### PR TITLE
Convert shared string table from hash to RB tree.

### DIFF
--- a/include/xlsxwriter/shared_strings.h
+++ b/include/xlsxwriter/shared_strings.h
@@ -12,11 +12,8 @@
 
 #include <string.h>
 #include <stdint.h>
-#include "xlsxwriter/third_party/queue.h"
 
 #include "common.h"
-
-#define NUM_SST_BUCKETS 1024
 
 /* STAILQ_HEAD() declaration. */
 struct sst_order_list {
@@ -24,22 +21,28 @@ struct sst_order_list {
     struct sst_element **stqh_last;
 };
 
-/* SLIST_HEAD() declaration. */
-struct sst_bucket_list {
-    struct sst_element *slh_first;
-};
+/* Define a tree.h RB structure for storing shared strings. */
+RB_HEAD(sst_rb_tree, sst_element);
+
+/* Wrapper around RB_GENERATE_STATIC from tree.h to avoid unused function
+ * warnings and to avoid portability issues with the _unused attribute. */
+#define LXW_RB_GENERATE_ELEMENT(name, type, field, cmp)     \
+    RB_GENERATE_INSERT_COLOR(name, type, field, static) \
+    RB_GENERATE_INSERT(name, type, field, cmp, static)  \
+    /* Add unused struct to allow adding a semicolon */ \
+    struct lxw_rb_generate_element{int unused;}
 
 /*
  * Elements of the SST table. They contain pointers to allow them to
- * be stored in lists in the the hash table buckets and also pointers to
- * track the insertion order in a separate list.
+ * be stored in a RB tree and also pointers to track the insertion order
+ * in a separate list.
  */
 struct sst_element {
     uint32_t index;
     char *string;
 
     STAILQ_ENTRY (sst_element) sst_order_pointers;
-    SLIST_ENTRY (sst_element) sst_list_pointers;
+    RB_ENTRY (sst_element) sst_tree_pointers;
 };
 
 /*
@@ -48,13 +51,11 @@ struct sst_element {
 typedef struct lxw_sst {
     FILE *file;
 
-    uint32_t num_buckets;
-    uint32_t used_buckets;
     uint32_t string_count;
     uint32_t unique_count;
 
     struct sst_order_list *order_list;
-    struct sst_bucket_list **buckets;
+    struct sst_rb_tree *rb_tree;
 
 } lxw_sst;
 


### PR DESCRIPTION
This speeds up generation of spreadsheets with large numbers of strings.