### PR TITLE
Add ability to build pod as a framework

### DIFF
--- a/cocoapods/libxlsxwriter-umbrella.h
+++ b/cocoapods/libxlsxwriter-umbrella.h
@@ -1,0 +1,28 @@
+#import <UIKit/UIKit.h>
+
+#import "../xlsxwriter.h"
+#import "app.h"
+#import "chart.h"
+#import "common.h"
+#import "content_types.h"
+#import "core.h"
+#import "drawing.h"
+#import "format.h"
+#import "hash_table.h"
+#import "packager.h"
+#import "relationships.h"
+#import "shared_strings.h"
+#import "styles.h"
+#import "theme.h"
+#import "third_party/minizip/ioapi.h"
+#import "third_party/minizip/zip.h"
+#import "third_party/queue.h"
+#import "third_party/tree.h"
+#import "utility.h"
+#import "workbook.h"
+#import "worksheet.h"
+#import "xmlwriter.h"
+
+FOUNDATION_EXPORT double xlsxwriterVersionNumber;
+FOUNDATION_EXPORT const unsigned char xlsxwriterVersionString[];
+

--- a/cocoapods/libxlsxwriter.modulemap
+++ b/cocoapods/libxlsxwriter.modulemap
@@ -1,0 +1,7 @@
+framework module xlsxwriter {
+  umbrella header "libxlsxwriter-umbrella.h"
+  header "../xlsxwriter.h"
+  
+  export *
+  module * { export * }
+}

--- a/libxlsxwriter.podspec
+++ b/libxlsxwriter.podspec
@@ -38,4 +38,9 @@ Pod::Spec.new do |s|
   s.header_mappings_dir   = "include/xlsxwriter"
   s.library               = "z"
   s.compiler_flags        = "-DNOCRYPT=1", "-DNOUNCRYPT=1"
+  s.pod_target_xcconfig   = { 'USER_HEADER_SEARCH_PATHS' => '${PODS_ROOT}/libxlsxwriter/include' }
+  s.module_map            = "cocoapods/libxlsxwriter.modulemap"
+  s.prepare_command       = <<-CMD
+                            cp cocoapods/libxlsxwriter-umbrella.h include/xlsxwriter/libxlsxwriter-umbrella.h
+                          CMD
 end


### PR DESCRIPTION

## TL;DR

With the final version of CocoaPods 1.0.0 out, I made another attempt and was able to add support for `use_frameworks!` without the need for introducing an additional subspec. I now recommend merging this PR over my previous one. However, I’m leaving the old PR open as well until the whole discussion on this topic is closed.

## The nitty-gritty

I started out as in the previous PR (#44), thus since a straight build of the current pod with `use_frameworks!` leads to:

![01](https://cloud.githubusercontent.com/assets/2843411/15742909/05c029ac-28c2-11e6-8718-4f681160b37e.png)

I added

```ruby
s.pod_target_xcconfig   = { 'USER_HEADER_SEARCH_PATHS' => '${PODS_ROOT}/libxlsxwriter/include’ }
```

in the podspec.

Then a new problem arose:

![02](https://cloud.githubusercontent.com/assets/2843411/15742913/0b6b28ac-28c2-11e6-826f-5496ce801c67.png)

In my previous PR, I solved this error by moving the `xlsxwriter.h` header inside of the `xlsxwriter` directory. However, what **I had missed out** is that it is possible to [specify a custom module map file](https://guides.cocoapods.org/syntax/podspec.html#module_map) in the podspec. According to the [Clang documentation](http://clang.llvm.org/docs/Modules.html#module-maps), a module map
> describes how a collection of existing headers maps on to the (logical) structure of a module.

Taking inspiration from the module map file that is usually generated by CocoaPods, I wrote a (slightly) custom one as follows:

```
framework module xlsxwriter {
  umbrella header "libxlsxwriter-umbrella.h"
  header "../xlsxwriter.h"
  
  export *
  module * { export * }
}
```
The second line inside the block fixes the compilation error. Hooray!

## Oh wait, we’re not done yet

A new compilation error arose since the `xlsxwriter` framework is now missing the umbrella header, because CocoaPods doesn’t automacally generate it when specifying a custom module map file. Actually, this is not a bug but a [feature](https://github.com/CocoaPods/CocoaPods/issues/4094#issuecomment-135643151). I then took the umbrella header previously generated by CocoaPods and manually added it to the repo. Since I didn’t want to pollute the `include` directory that is shared with other platforms, I created a new `cocoapods` directory with the module map and umbrella header files inside and added these lines to the podspec:
```ruby
  s.prepare_command       = <<-CMD
                            cp cocoapods/libxlsxwriter-umbrella.h include/xlsxwriter/libxlsxwriter-umbrella.h
                          CMD

```

## The bottom line

The obvious disadvantage of this solution is that whenever a new header file is added to the project, we need to remember to manually include it in the umbrella header. However, I still tend to favor this solution over my previous one since (1) it seems cleaner and (2) the pod can now be added to a project with a simple

```ruby
pod 'libxlsxwriter'
```

in the Podfile, regardless of whether the `use_frameworks!` directive is specified or not.

**What do you think?**

*P.S. If you want to quickly try it out, I made another [branch](https://github.com/lrossi/libxlsxwriterCocoaExamples/tree/update-cocoapods) in my example repo that uses this PR to import the pod.*