### PR TITLE
[PROPOSAL] ability to specify cell's format without changing cell's content

### DIFF
--- a/include/xlsxwriter/worksheet.h
+++ b/include/xlsxwriter/worksheet.h
@@ -92,6 +92,7 @@ enum cell_types {
     ARRAY_FORMULA_CELL,
     BLANK_CELL,
     BOOLEAN_CELL,
+    NULL_CELL,
     HYPERLINK_URL,
     HYPERLINK_INTERNAL,
     HYPERLINK_EXTERNAL
@@ -919,6 +920,52 @@ lxw_error worksheet_write_boolean(lxw_worksheet *worksheet,
                                   lxw_row_t row, lxw_col_t col,
                                   int value, lxw_format *format);
 
+/**
+ * @brief Write a format information in a worksheet cell.
+ *
+ * @param worksheet pointer to a lxw_worksheet instance to be updated.
+ * @param row       The zero indexed row number.
+ * @param col       The zero indexed column number.
+ * @param format    A pointer to a Format instance or NULL.
+ *
+ * @return A #lxw_error code.
+ *
+ * Write an Excel format into the cell specified by `row` and `column`:
+ *
+ * @code
+ *     worksheet_write_format(worksheet, 2, 2, my_format);
+ * @endcode
+ *
+ */
+lxw_error
+worksheet_write_format(lxw_worksheet *self,
+                        lxw_row_t row_num, lxw_col_t col_num,
+                        lxw_format *format);
+
+/**
+ * @brief Write a format information in a worksheet range of cells.
+ *
+ * @param worksheet pointer to a lxw_worksheet instance to be updated.
+ * @param first_row   The zero indexed row number.
+ * @param first_col   The zero indexed column number.
+ * @param last_row    The zero indexed row number.
+ * @param last_col    The zero indexed column number.
+ * @param format    A pointer to a Format instance or NULL.
+ *
+ * @return A #lxw_error code.
+ *
+ * Write an Excel format into the cells specified by (`first_row`, `first_col`) and (`last_row`, `last_col`)
+ *
+ * @code
+ *     worksheet_write_format(worksheet, 2, 2, 4, 4, my_format);
+ * @endcode
+ *
+ */
+lxw_error
+worksheet_write_range_format(lxw_worksheet *self, lxw_row_t first_row,
+                       lxw_col_t first_col, lxw_row_t last_row,
+                       lxw_col_t last_col,
+                       lxw_format *format);
 /**
  * @brief Write a formatted blank worksheet cell.
  *

--- a/src/worksheet.c
+++ b/src/worksheet.c
@@ -220,7 +220,9 @@ _free_cell(lxw_cell *cell)
         return;
 
     if (cell->type != NUMBER_CELL && cell->type != STRING_CELL
-        && cell->type != BLANK_CELL && cell->type != BOOLEAN_CELL) {
+        && cell->type != BLANK_CELL && cell->type != BOOLEAN_CELL
+        && cell->type != NULL_CELL
+        ) {
 
         free(cell->u.string);
     }
@@ -576,6 +578,25 @@ _new_boolean_cell(lxw_row_t row_num, lxw_col_t col_num, int value,
 }
 
 /*
+ * Create a new worksheet null cell object.
+ */
+STATIC lxw_cell *
+_new_null_cell(lxw_row_t row_num, lxw_col_t col_num,
+                  lxw_format *format)
+{
+    lxw_cell *cell = calloc(1, sizeof(lxw_cell));
+    RETURN_ON_MEM_ERROR(cell, cell);
+
+    cell->row_num = row_num;
+    cell->col_num = col_num;
+    cell->type = NULL_CELL;
+    cell->format = format;
+    cell->u.string = 0;
+
+    return cell;
+}
+
+/*
  * Create a new worksheet hyperlink cell object.
  */
 STATIC lxw_cell *
@@ -661,6 +682,7 @@ STATIC void
 _insert_cell_list(struct lxw_table_cells *cell_list,
                   lxw_cell *cell, lxw_col_t col_num)
 {
+    lxw_format *format;
     lxw_cell *existing_cell;
 
     cell->col_num = col_num;
@@ -670,6 +692,15 @@ _insert_cell_list(struct lxw_table_cells *cell_list,
     /* If existing_cell is not NULL, then that cell already existed. */
     /* Remove existing_cell and add new one in again. */
     if (existing_cell) {
+        format = cell->format;
+        *cell  = *existing_cell;
+        cell->format = format;
+        /*Waiting comment on this point from the author
+         *  How to do it properly ?
+         */
+        memset(existing_cell, 0, sizeof(lxw_cell));
+        existing_cell->type = BLANK_CELL;
+
         RB_REMOVE(lxw_table_cells, cell_list, existing_cell);
 
         /* Add it in again. */
@@ -687,6 +718,7 @@ STATIC void
 _insert_cell(lxw_worksheet *self, lxw_row_t row_num, lxw_col_t col_num,
              lxw_cell *cell)
 {
+    lxw_format *format;
     lxw_row *row = _get_row(self, row_num);
 
     if (!self->optimize) {
@@ -698,8 +730,19 @@ _insert_cell(lxw_worksheet *self, lxw_row_t row_num, lxw_col_t col_num,
             row->data_changed = LXW_TRUE;
 
             /* Overwrite an existing cell if necessary. */
-            if (self->array[col_num])
+            if (self->array[col_num]) {
+                if (cell->type == NULL_CELL) {
+                    format = cell->format;
+                    *cell  = *self->array[col_num];
+                    cell->format = format;
+                    /*Waiting comment on this point from the author
+                     *  How to do it properly ?
+                     */
+                    memset(self->array[col_num], 0, sizeof(lxw_cell));
+                    self->array[col_num]->type = BLANK_CELL;
+                }
                 _free_cell(self->array[col_num]);
+            }
 
             self->array[col_num] = cell;
         }
@@ -2570,7 +2613,7 @@ _write_cell(lxw_worksheet *self, lxw_cell *cell, lxw_format *row_format)
         _write_formula_num_cell(self, cell);
         lxw_xml_end_tag(self->file, "c");
     }
-    else if (cell->type == BLANK_CELL) {
+    else if (cell->type == BLANK_CELL || cell->type == NULL_CELL) {
         lxw_xml_empty_tag(self->file, "c", &attributes);
     }
     else if (cell->type == BOOLEAN_CELL) {
@@ -3637,6 +3680,68 @@ worksheet_write_boolean(lxw_worksheet *self,
     cell = _new_boolean_cell(row_num, col_num, value, format);
 
     _insert_cell(self, row_num, col_num, cell);
+
+    return LXW_NO_ERROR;
+}
+
+/*
+ * Write a cell with a format; doesn't change cell content
+ */
+lxw_error
+worksheet_write_format(lxw_worksheet *self,
+                        lxw_row_t row_num, lxw_col_t col_num,
+                        lxw_format *format)
+{
+    lxw_cell *cell;
+    lxw_error err;
+
+    err = _check_dimensions(self, row_num, col_num, LXW_FALSE, LXW_FALSE);
+
+    if (err)
+        return err;
+
+    cell = _new_null_cell(row_num, col_num, format);
+
+    _insert_cell(self, row_num, col_num, cell);
+
+    return LXW_NO_ERROR;
+}
+
+/*
+ * Write a range of cells with a format; doesn't change cells content
+ */
+lxw_error
+worksheet_write_range_format(lxw_worksheet *self, lxw_row_t first_row,
+                       lxw_col_t first_col, lxw_row_t last_row,
+                       lxw_col_t last_col,
+                       lxw_format *format)
+{
+    lxw_row_t i, tmp_row;
+    lxw_col_t j, tmp_col;
+    lxw_error err;
+
+    /* Excel doesn't allow a single cell to be merged */
+    if (first_row == last_row && first_col == last_col)
+        return LXW_ERROR_PARAMETER_VALIDATION;
+    /* Swap last row/col with first row/col as necessary */
+    if (first_row > last_row) {
+        tmp_row = last_row;
+        last_row = first_row;
+        first_row = tmp_row;
+    }
+    if (first_col > last_col) {
+        tmp_col = last_col;
+        last_col = first_col;
+        first_col = tmp_col;
+    }
+    /* Check that column number is valid and store the max value */
+    err = _check_dimensions(self, last_row, last_col, LXW_FALSE, LXW_FALSE);
+    if (err)
+        return err;
+    for( i = first_row ; i <= last_row ; i++)
+        for( j = first_col ; j <= last_col ; j++)
+            if ((err = worksheet_write_format(self, i, j, format)) != LXW_NO_ERROR)
+              return err;
 
     return LXW_NO_ERROR;
 }


### PR DESCRIPTION
Hi.

I have the need to play with borders and it is easier for me to set the data and the cells format at different time.

So as I found this in the FAQ:
> Q. Can I apply a format to a range of cells in one go?

I told myself: why not contribute to that library that is usefull for you (and you seemed a little tired as I readed it through some of your messages).

This is not a real proposal for a pull as:
- I loosely checked your coding style
- I didn't add any test
- I didn't perform real test (but the code is fully fonctionnal in my use cases)
- I have some doubt (please take a look at src/worksheet.c comments)

I just want a small code review, advices, and validation of the way to do it.

Commit message:
 [PROPOSAL] added the ability to specify cells format without changing cells value.

I used a "phantom" cell type (NULL_CELL), and altered _insert_cell_list and _insert_cell.
There is still question about how clean a cell (c.f. /*Waiting comment ).

Two public functions are now available:
- worksheet_write_format that allows to change format of one cell
- worksheet_write_range_format that allows to change format of a range of cells