### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/src/faq.dox
+++ b/docs/src/faq.dox
@@ -47,7 +47,7 @@ Yes. See @ref gsg_msvc.
 
 All supported features are documented. In time the feature set may expand to
 include more of the functionality of the [Python
-XlsxWriter](http://xlsxwriter.readthedocs.org) module.
+XlsxWriter](https://xlsxwriter.readthedocs.io) module.
 
 
 @section faq_autofit Q. Is there an "AutoFit" option for columns?

--- a/docs/src/introduction.dox
+++ b/docs/src/introduction.dox
@@ -22,7 +22,7 @@ However:
 
 Libxlsxwriter is a C port of the Perl
 [Excel::Writer::XLSX](http://search.cpan.org/~jmcnamara/Excel-Writer-XLSX/)
-module and the Python [XlsxWriter](http://xlsxwriter.readthedocs.org) module
+module and the Python [XlsxWriter](https://xlsxwriter.readthedocs.io) module
 and is licensed under a FreeBSD @ref license.
 
 Next: @ref getting_started


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.