### PR TITLE
Fixes 3 Issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,18 @@
+build:
+  image: teaci/msys$$arch
+  pull: true
+  shell: msys$$arch
+  commands:
+    - if [ $$arch = 32 ]; then target=i686; fi
+    - if [ $$arch = 64 ]; then target=x86_64; fi
+    - pacman -S --needed --noconfirm --noprogressbar mingw-w64-${target}-pkg-config cmake zlib-devel
+    - git submodule update --init --recursive
+    - cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DIOAPI_NO_64=ON .
+    - make -j 8
+    - ctest -C Release -V
+
+matrix:
+  arch:
+# Bug with 64-bit MSYS2 on WINE currently, disable temporarily.
+#    - 64
+    - 32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,13 @@
 #           https://cmake.org/cmake/help/v3.0/manual/cmake-generators.7.html
 #
 
+set(CMAKE_LEGACY_CYGWIN_WIN32 1)
 cmake_minimum_required(VERSION 2.8)
 
 SET(PROJECT_NAME "xlsxwriter" CACHE STRING "Optional project and binary name")
 
 project(${PROJECT_NAME} C)
+enable_testing()
 
 # OPTIONS
 # -------
@@ -75,8 +77,13 @@ option(BUILD_STATIC "Build static libxlsxwriter" ON)
 option(BUILD_TESTS "Build libxlsxwriter tests" OFF)
 option(BUILD_EXAMPLES "Build libxlsxwriter examples" OFF)
 option(USE_STANDARD_TMPFILE "Use the C standard library's tmpfile()" OFF)
+option(IOAPI_NO_64 "Disable 64-bit filesystem support" OFF)
 if(DEFINED ENV{${ZLIB_ROOT}})
     set(ZLIB_ROOT $ENV{ZLIB_ROOT})
+endif()
+
+if(IOAPI_NO_64)
+    add_definitions(-DIOAPI_NO_64=1)
 endif()
 
 # CONFIGURATIONS
@@ -89,7 +96,7 @@ endif()
 if(BUILD_STATIC)
     if(UNIX)
         set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    elseif(${MINGW} OR ${MSYS})
+    elseif(MINGW OR MSYS)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static -static-libgcc -Wno-char-subscripts -Wno-long-long")
         add_definitions(-DUSE_FILE32API)
     elseif(MSVC)
@@ -114,6 +121,9 @@ add_definitions(-DNOCRYPT -DNOUNCRYPT)
 include_directories(include include/xlsxwriter)
 file(GLOB LXW_SOURCES src/*.c)
 list(APPEND LXW_SOURCES third_party/minizip/ioapi.c third_party/minizip/zip.c)
+if(MSVC)
+    list(APPEND LXW_SOURCES third_party/minizip/iowin32.c)
+endif()
 if (NOT ${USE_STANDARD_TMPFILE})
     include_directories(third_party/tmpfileplus)
     list(APPEND LXW_SOURCES third_party/tmpfileplus/tmpfileplus.c)
@@ -151,9 +161,9 @@ macro(CreateTest sources target)
 
     add_executable(${output_name} ${${sources}})
     target_link_libraries(${output_name} ${PROJECT_NAME} ${ZLIB_LIBRARIES})
-    add_custom_target(check_${output_name}
-        COMMAND $<TARGET_FILE:${output_name}>
-        DEPENDS ${dependencies}
+    add_test(NAME ${output_name}
+        COMMAND ${output_name}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 endmacro(CreateTest)
 
@@ -241,7 +251,7 @@ if(MSVC)
         install(FILES $<TARGET_FILE_DIR:${PROJECT_NAME}>/${PROJECT_NAME}.pdb
             DESTINATION "lib/Win32/\${CMAKE_INSTALL_CONFIG_NAME}"
         )
-    endif()   
+    endif()
 else(MSVC)
     install(TARGETS ${PROJECT_NAME}
         LIBRARY DESTINATION lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+version: '{build}'
+
+os:
+  - Visual Studio 2015
+  - Visual Studio 2017
+
+environment:
+  matrix:
+  - additional_flags: ""
+  - additional_flags: "/std:c++latest"
+
+matrix:
+  exclude:
+    - additional_flags: "/std:c++latest"
+      os: Visual Studio 2015
+
+init: []
+
+install: []
+
+build_script:
+  # Set the correct generator
+  - IF "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" ( SET GEN="Visual Studio 14 2015") ELSE (SET GEN="Visual Studio 15 2017")
+  # ZLIB isn't included on Windows, and no package manager has a static,
+  # /MT-linked build, so we can download it and build it ourselves
+  - appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
+  - 7z x zlib-1.2.11.tar.gz > NUL
+  - 7z x zlib-1.2.11.tar > NUL
+  - cd zlib-1.2.11
+  - cmake -G %GEN% -DCMAKE_C_FLAGS_RELEASE="/MT"
+  - cmake --build . --config Release
+  # Configure libxlsxwriter to use the static ZLIB
+  - cd ..
+  - cmake . -G%GEN% -DBUILD_TESTS=ON -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11\Release\zlibstatic.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11
+  - cmake --build . --config Release
+
+test_script:
+  - ctest -C Release -V


### PR DESCRIPTION
Hi @jmcnamara, this PR fixes 3 issues we've previously discussed, and adds continual integration for MSYS2 (one that we had not discussed). It's broken into 3 commits accordingly.

1. Fixes [issue 108](https://github.com/jmcnamara/libxlsxwriter/issues/108) so the CMake generation properly includes iowin32.c.
2. Fixes [issue 107](https://github.com/jmcnamara/libxlsxwriter/issues/107) to make unittests work on MSVC.
3. Adds continual integration for AppVeyor (Visual Studio 2015 and Visual Studio 2017) and [Tea-CI](https://tea-ci.org/Alexhuszagh/libxlsxwriter) (MSYS2).

Combined, this should be good assurance that the CMake builds work on a large variety of platforms, in addition to the Makefile builds, which is especially useful for Visual Studio.

I also need to submit a PR for an example for a CMake example, which I can do later tonight.