### PR TITLE
MSVC and Shared Linkage Bug Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,10 @@ if (BUILD_TESTS)
     #endforeach(source)
 endif()
 
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 # EXAMPLES
 # --------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ else()
     add_library(${PROJECT_NAME} SHARED ${LXW_SOURCES})
 endif()
 
+target_link_libraries(${PROJECT_NAME} ${ZLIB_LIBRARIES})
+
 if(MSVC)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E rename


### PR DESCRIPTION
Patch for issues discovered in #115, as well as a patch to remove numerous superfluous errors by MSVC by setting the `_CRT_SECURE_NO_WARNINGS` flag (MSVC warns for functions that may lead to a buffer overflow, but warns for functions `fread` and `snprintf`, which already require you to provide to length of the destination buffer, so the CRT warnings are effectively useless IMO, especially when you require the use of standard C/POSIX functions).