### PR TITLE
Fix for Issue #153

### DIFF
--- a/src/packager.c
+++ b/src/packager.c
@@ -62,7 +62,7 @@ _open_zipfile_win32(const char *filename)
     }
 
     /* Use the native Win32 file handling functions with minizip. */
-    fill_win32_filefunc64(&filefunc);
+    fill_win32_filefunc64W(&filefunc);
 
     return zipOpen2_64(wide_filename, 0, NULL, &filefunc);
 }


### PR DESCRIPTION
Patch to fix issue #153. As my Windows development machine is currently down, I cannot comprehensively test it, but it's been testing using cross-compilation on Fedora MinGW without issues.

Steps. to confirm it works (cross-compiling):

1. `git clone https://github.com/Alexhuszagh/libxlsxwriter && cd libxlsxwriter`
2. `mkdir build && cd build`
3. `wget https://github.com/madler/zlib/archive/v1.2.11.zip`
4. `unzip v1.2.11.zip`
5. `cd zlib-1.2.11`
6. `cmake . # -DCMAKE_C_FLAGS="-D_UNICODE"`
7. `cd ..`
8. `cmake .. -DBUILD_TESTS=ON -DZLIB_INCLUDE_DIR=zlib-1.2.11 -DZLIB_LIBRARY=zlib-1.2.11/libzlibstatic.a # -DCMAKE_C_FLAGS="-D_UNICODE"`

I've tried all 4 forms of the `_UNICODE` combinations cross-compiling, so it should work.

Thoughts @RalfKubis, @jmcnamara?