### PR TITLE
Fix for spurious PDB renaming.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,16 +216,6 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC include include/xlsxwriter
 )
 
-if(MSVC)
-    if (NOT BUILD_SHARED_LIBS)
-        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E rename
-            ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pdb
-            $<TARGET_FILE_DIR:${PROJECT_NAME}>/${PROJECT_NAME}.pdb
-        )
-    endif()
-endif()
-
 # TESTS
 # -----
 
@@ -329,7 +319,7 @@ if(MSVC)
         RUNTIME DESTINATION "bin/${MSVC_FOLDER_PREFIX}/\${CMAKE_INSTALL_CONFIG_NAME}"
     )
     if (NOT BUILD_SHARED_LIBS)
-        install(FILES $<TARGET_FILE_DIR:${PROJECT_NAME}>/${PROJECT_NAME}.pdb
+        install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pdb
             DESTINATION "lib/${MSVC_FOLDER_PREFIX}/\${CMAKE_INSTALL_CONFIG_NAME}"
         )
     endif()


### PR DESCRIPTION
I tracked down the origin of the code for the PDB renaming, since it retrospect it seemed suspect to me. It was part of the following [commit](https://github.com/jmcnamara/libxlsxwriter/commit/9a78c323a925c75d8feffb7c3f6a7773e79d2628#diff-af3b638bc2a3e6c650974192a53c7291), which added various hardcoded values for certain common use cases we've had to subsequently remove for good reason.

The more I looked at the code, the more I realized that re-writing the PDB (symbol info) for a specific build to a global project directory is a bad idea, and that was should be only installing from the project-specific PDB anyway.

Hence, the changes. I'll be careful to review code more carefully before signing off on it in the future. This fixes #175.