### PR TITLE
add lxw_version function to rerieve runtime library version

### DIFF
--- a/include/xlsxwriter/utility.h
+++ b/include/xlsxwriter/utility.h
@@ -163,6 +163,13 @@ int lxw_sprintf_dbl(char *data, double number);
         lxw_snprintf(data, LXW_ATTR_32, "%.16g", number)
 #endif
 
+/**
+ * @brief Retrieve runtime library version
+ *
+ * @return A pointer to a statically allocated string. Do not free.
+ */
+const char *lxw_version(void);
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
 }

--- a/src/utility.c
+++ b/src/utility.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include "xlsxwriter/utility.h"
+#include "xlsxwriter.h"
 #include "xlsxwriter/third_party/tmpfileplus.h"
 
 char *error_strings[LXW_MAX_ERRNO + 1] = {
@@ -553,3 +553,12 @@ lxw_sprintf_dbl(char *data, double number)
     return 0;
 }
 #endif
+
+/*
+ * Retrieve runtime library version
+ */
+const char *
+lxw_version(void)
+{
+    return LXW_VERSION;
+}


### PR DESCRIPTION
May be useful to check build time version (LXW_VERSION) against runtime version, and to display information in some debug part.