### PR TITLE
Make py.test name configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ endif
 
 INSTALL_DIR ?= /usr/local
 
+PYTEST ?= py.test
+
 .PHONY: docs tags examples
 
 # Build the libs.
@@ -58,7 +60,7 @@ test_const : all
 # Run the functional tests.
 test_functional : all
 	$(Q)$(MAKE) -C test/functional/src
-	$(Q)py.test test/functional -v
+	$(Q)$(PYTEST) test/functional -v
 
 # Run all tests.
 test_unit :


### PR DESCRIPTION
This came up whilst packaging for pkgsrc which adds a Python version
suffix to binaries.

Relates to #205.