### PR TITLE
Fix compile-time warnings with strict prototypes enabled. Fixes #208

### DIFF
--- a/include/xlsxwriter/app.h
+++ b/include/xlsxwriter/app.h
@@ -56,7 +56,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_app *lxw_app_new();
+lxw_app *lxw_app_new(void);
 void lxw_app_free(lxw_app *app);
 void lxw_app_assemble_xml_file(lxw_app *self);
 void lxw_app_add_part_name(lxw_app *self, const char *name);

--- a/include/xlsxwriter/chartsheet.h
+++ b/include/xlsxwriter/chartsheet.h
@@ -524,7 +524,7 @@ lxw_error chartsheet_set_footer_opt(lxw_chartsheet *chartsheet,
                                     const char *string,
                                     lxw_header_footer_options *options);
 
-lxw_chartsheet *lxw_chartsheet_new(void);
+lxw_chartsheet *lxw_chartsheet_new(lxw_worksheet_init_data *init_data);
 void lxw_chartsheet_free(lxw_chartsheet *chartsheet);
 void lxw_chartsheet_assemble_xml_file(lxw_chartsheet *chartsheet);
 

--- a/include/xlsxwriter/chartsheet.h
+++ b/include/xlsxwriter/chartsheet.h
@@ -524,7 +524,7 @@ lxw_error chartsheet_set_footer_opt(lxw_chartsheet *chartsheet,
                                     const char *string,
                                     lxw_header_footer_options *options);
 
-lxw_chartsheet *lxw_chartsheet_new();
+lxw_chartsheet *lxw_chartsheet_new(void);
 void lxw_chartsheet_free(lxw_chartsheet *chartsheet);
 void lxw_chartsheet_assemble_xml_file(lxw_chartsheet *chartsheet);
 

--- a/include/xlsxwriter/content_types.h
+++ b/include/xlsxwriter/content_types.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_content_types *lxw_content_types_new();
+lxw_content_types *lxw_content_types_new(void);
 void lxw_content_types_free(lxw_content_types *content_types);
 void lxw_content_types_assemble_xml_file(lxw_content_types *content_types);
 void lxw_ct_add_default(lxw_content_types *content_types, const char *key,

--- a/include/xlsxwriter/core.h
+++ b/include/xlsxwriter/core.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_core *lxw_core_new();
+lxw_core *lxw_core_new(void);
 void lxw_core_free(lxw_core *core);
 void lxw_core_assemble_xml_file(lxw_core *self);
 

--- a/include/xlsxwriter/custom.h
+++ b/include/xlsxwriter/custom.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_custom *lxw_custom_new();
+lxw_custom *lxw_custom_new(void);
 void lxw_custom_free(lxw_custom *custom);
 void lxw_custom_assemble_xml_file(lxw_custom *self);
 

--- a/include/xlsxwriter/drawing.h
+++ b/include/xlsxwriter/drawing.h
@@ -90,7 +90,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_drawing *lxw_drawing_new();
+lxw_drawing *lxw_drawing_new(void);
 void lxw_drawing_free(lxw_drawing *drawing);
 void lxw_drawing_assemble_xml_file(lxw_drawing *self);
 void lxw_free_drawing_object(struct lxw_drawing_object *drawing_object);

--- a/include/xlsxwriter/format.h
+++ b/include/xlsxwriter/format.h
@@ -480,7 +480,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_format *lxw_format_new();
+lxw_format *lxw_format_new(void);
 void lxw_format_free(lxw_format *format);
 int32_t lxw_format_get_xf_index(lxw_format *format);
 lxw_font *lxw_format_get_font_key(lxw_format *format);

--- a/include/xlsxwriter/relationships.h
+++ b/include/xlsxwriter/relationships.h
@@ -47,7 +47,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_relationships *lxw_relationships_new();
+lxw_relationships *lxw_relationships_new(void);
 void lxw_free_relationships(lxw_relationships *relationships);
 void lxw_relationships_assemble_xml_file(lxw_relationships *self);
 

--- a/include/xlsxwriter/shared_strings.h
+++ b/include/xlsxwriter/shared_strings.h
@@ -63,7 +63,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_sst *lxw_sst_new();
+lxw_sst *lxw_sst_new(void);
 void lxw_sst_free(lxw_sst *sst);
 struct sst_element *lxw_get_sst_index(lxw_sst *sst, const char *string,
                                       uint8_t is_rich_string);

--- a/include/xlsxwriter/styles.h
+++ b/include/xlsxwriter/styles.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_styles *lxw_styles_new();
+lxw_styles *lxw_styles_new(void);
 void lxw_styles_free(lxw_styles *styles);
 void lxw_styles_assemble_xml_file(lxw_styles *self);
 void lxw_styles_write_string_fragment(lxw_styles *self, char *string);

--- a/include/xlsxwriter/theme.h
+++ b/include/xlsxwriter/theme.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-lxw_theme *lxw_theme_new();
+lxw_theme *lxw_theme_new(void);
 void lxw_theme_free(lxw_theme *theme);
 void lxw_theme_xml_declaration(lxw_theme *self);
 void lxw_theme_assemble_xml_file(lxw_theme *self);

--- a/src/app.c
+++ b/src/app.c
@@ -25,7 +25,7 @@
  * Create a new app object.
  */
 lxw_app *
-lxw_app_new()
+lxw_app_new(void)
 {
     lxw_app *app = calloc(1, sizeof(lxw_app));
     GOTO_LABEL_ON_MEM_ERROR(app, mem_error);

--- a/src/content_types.c
+++ b/src/content_types.c
@@ -25,7 +25,7 @@
  * Create a new content_types object.
  */
 lxw_content_types *
-lxw_content_types_new()
+lxw_content_types_new(void)
 {
     lxw_content_types *content_types = calloc(1, sizeof(lxw_content_types));
     GOTO_LABEL_ON_MEM_ERROR(content_types, mem_error);

--- a/src/core.c
+++ b/src/core.c
@@ -25,7 +25,7 @@
  * Create a new core object.
  */
 lxw_core *
-lxw_core_new()
+lxw_core_new(void)
 {
     lxw_core *core = calloc(1, sizeof(lxw_core));
     GOTO_LABEL_ON_MEM_ERROR(core, mem_error);

--- a/src/custom.c
+++ b/src/custom.c
@@ -25,7 +25,7 @@
  * Create a new custom object.
  */
 lxw_custom *
-lxw_custom_new()
+lxw_custom_new(void)
 {
     lxw_custom *custom = calloc(1, sizeof(lxw_custom));
     GOTO_LABEL_ON_MEM_ERROR(custom, mem_error);

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -27,7 +27,7 @@
  * Create a new drawing collection.
  */
 lxw_drawing *
-lxw_drawing_new()
+lxw_drawing_new(void)
 {
     lxw_drawing *drawing = calloc(1, sizeof(lxw_drawing));
     GOTO_LABEL_ON_MEM_ERROR(drawing, mem_error);

--- a/src/format.c
+++ b/src/format.c
@@ -21,7 +21,7 @@
  * Create a new format object.
  */
 lxw_format *
-lxw_format_new()
+lxw_format_new(void)
 {
     lxw_format *format = calloc(1, sizeof(lxw_format));
     GOTO_LABEL_ON_MEM_ERROR(format, mem_error);

--- a/src/relationships.c
+++ b/src/relationships.c
@@ -26,7 +26,7 @@
  * Create a new relationships object.
  */
 lxw_relationships *
-lxw_relationships_new()
+lxw_relationships_new(void)
 {
     lxw_relationships *rels = calloc(1, sizeof(lxw_relationships));
     GOTO_LABEL_ON_MEM_ERROR(rels, mem_error);

--- a/src/shared_strings.c
+++ b/src/shared_strings.c
@@ -34,7 +34,7 @@ LXW_RB_GENERATE_ELEMENT(sst_rb_tree, sst_element, sst_tree_pointers,
  * Create a new SST SharedString object.
  */
 lxw_sst *
-lxw_sst_new()
+lxw_sst_new(void)
 {
     /* Create the new shared string table. */
     lxw_sst *sst = calloc(1, sizeof(lxw_sst));

--- a/src/styles.c
+++ b/src/styles.c
@@ -27,7 +27,7 @@ STATIC void _write_font(lxw_styles *self, lxw_format *format,
  * Create a new styles object.
  */
 lxw_styles *
-lxw_styles_new()
+lxw_styles_new(void)
 {
     lxw_styles *styles = calloc(1, sizeof(lxw_styles));
     GOTO_LABEL_ON_MEM_ERROR(styles, mem_error);

--- a/src/theme.c
+++ b/src/theme.c
@@ -289,7 +289,7 @@ const char *theme_strs[] = {
  * Create a new theme object.
  */
 lxw_theme *
-lxw_theme_new()
+lxw_theme_new(void)
 {
     lxw_theme *theme = calloc(1, sizeof(lxw_theme));
     GOTO_LABEL_ON_MEM_ERROR(theme, mem_error);

--- a/test/unit/chartsheet/test_chartsheet.c
+++ b/test/unit/chartsheet/test_chartsheet.c
@@ -30,7 +30,7 @@ CTEST(chartsheet, chartsheet) {
 
     lxw_chartsheet *chartsheet = lxw_chartsheet_new(NULL);
     chartsheet->file = testfile;
-    chartsheet->worksheet->drawing = lxw_drawing_new(NULL);
+    chartsheet->worksheet->drawing = lxw_drawing_new();
 
     lxw_chartsheet_assemble_xml_file(chartsheet);
 


### PR DESCRIPTION
The C standard (and `-Wstrict-prototypes`) requires that functions which take no arguments be declared as foobar(void) instead of foobar().