### PR TITLE
Additional debugging for temporary directory.

### DIFF
--- a/src/workbook.c
+++ b/src/workbook.c
@@ -1732,8 +1732,8 @@ workbook_close(lxw_workbook *self)
     /* If the packager fails it is generally due to a zip permission error. */
     if (packager == NULL) {
         fprintf(stderr, "[ERROR] workbook_close(): "
-                "Error creating '%s'. "
-                "Error = %s\n", self->filename, strerror(errno));
+                "Error creating '%s' using '%s'. "
+                "Error = %s\n", self->filename, self->options.tmpdir, strerror(errno));
 
         error = LXW_ERROR_CREATING_XLSX_FILE;
         goto mem_error;


### PR DESCRIPTION
After cross-compiling libxlsxwriter using gcc on Ubuntu 18.04 for Windows 64-bit, I kept encountering an error when trying to build any .xlsx file:
`[ERROR] workbook_close(): Error creating 'C:\temp\3.xlsx'. Error = No error`

In trying to track down what was causing the issue, it was helpful to see what the temporary directory was being set to:
`[ERROR] workbook_close(): Error creating 'C:\temp\3.xlsx' using '(null)'. Error = No error`

I still haven't tracked down why I'm getting an error, but I feel like I'm getting closer and thought that someone else could benefit from the extra error debugging.