### PR TITLE
CMake: Corrected message command call.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if(NOT BUILD_SHARED_LIBS)
     endif()
 endif()
 
-message(status "BEFORE: ${CMAKE_C_FLAGS_DEBUG}")
+message(STATUS "BEFORE: ${CMAKE_C_FLAGS_DEBUG}")
 
 if(MSVC AND USE_STATIC_MSVC_RUNTIME)
     foreach(flag_var CMAKE_C_FLAGS


### PR DESCRIPTION
The "status" message type must in upper case.