### PR TITLE
Patch for issue #243, by specifying the new policy for <PackageName>_ROOT.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,16 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 project(${PROJECT_NAME} C)
 enable_testing()
 
+# POLICY
+# ------
+
+# The use of the word ZLIB_ROOT should still work prior to "3.12.0",
+# just it's been generalized for all packages now. Just set the policy
+# to new, so we use it, and it will be used prior to 3.12 anyway.
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 # OPTIONS
 # -------
 


### PR DESCRIPTION
This should patch issue #243, and potentially #242. 

I've tested the following code produces no warnings, and respects the `ZLIB_ROOT` variable on the following CMake versions (on Linux, x86-64):

- 3.14.5
- 3.12.0
- 3.11.4 (The last release prior to 3.12.0)
- 3.9.2 (An arbitrary older release)