### PR TITLE
add LXW_VERSION_ID macro

### DIFF
--- a/include/xlsxwriter.h
+++ b/include/xlsxwriter.h
@@ -19,5 +19,7 @@
 #include "xlsxwriter/utility.h"
 
 #define LXW_VERSION "0.8.8"
+/* ID = Major = 1000000 + Minor * 1000 + Patch */
+#define LXW_VERSION_ID 8008
 
 #endif /* __LXW_XLSXWRITER_H__ */


### PR DESCRIPTION
API changes are quite difficult to track, thus having to use strange hacks such as https://github.com/viest/php-ext-xlswriter/pull/199

Having such a macro will make code compatibility simpler, ex:

```
#ifdef LXW_VERSION_ID >= 80008
        if (STAILQ_EMPTY(worksheet->image_props)
#else
        if (STAILQ_EMPTY(worksheet->image_data)
#endif

```

And also easier to clean, when minimal version will be raised.