### PR TITLE
Use DESTDIR and PREFIX instead of INSTALL_LOCATION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ ifdef V
 Q=
 endif
 
-INSTALL_DIR ?= /usr/local
+DESTIDR ?=
+PREFIX  ?= /usr/local
 
 PYTEST ?= py.test
 PYTESTFILES ?= test
@@ -123,15 +124,15 @@ docs:
 
 # Simple minded install.
 install: all
-	$(Q)mkdir -p        $(INSTALL_DIR)/include
-	$(Q)cp -R include/* $(INSTALL_DIR)/include
-	$(Q)mkdir -p        $(INSTALL_DIR)/lib
-	$(Q)cp lib/*        $(INSTALL_DIR)/lib
+	$(Q)mkdir -p        $(DESTDIR)$(PREFIX)/include
+	$(Q)cp -R include/* $(DESTDIR)$(PREFIX)/include
+	$(Q)mkdir -p        $(DESTDIR)$(PREFIX)/lib
+	$(Q)cp lib/*        $(DESTDIR)$(PREFIX)/lib
 
 # Simpler minded uninstall.
 uninstall:
-	$(Q)rm -rf $(INSTALL_DIR)/include/xlsxwriter*
-	$(Q)rm     $(INSTALL_DIR)/lib/libxlsxwriter.*
+	$(Q)rm -rf $(DESTDIR)$(PREFIX)/include/xlsxwriter*
+	$(Q)rm     $(DESTDIR)$(PREFIX)/lib/libxlsxwriter.*
 
 # Strip the lib files.
 strip:

--- a/docs/src/getting_started.dox
+++ b/docs/src/getting_started.dox
@@ -106,9 +106,17 @@ dynamic/shared library and header files.
     sudo make install
 
 The files are installed to `/usr/local` by default but this can be overridden
-by using the `INSTALL_DIR` environmental variable:
+by using the `PREFIX` environmental variable:
 
-    make install INSTALL_DIR=/usr/third_party
+    make install PREFIX=/usr/third_party
+
+A staging directory can be set with `DESTDIR` which is prepended to all
+install paths, a feature mostly useful for packaging:
+
+    make install PREFIX=/usr/third_party DESTDIR=./staging/
+
+This would build and link the code with `/usr/third_party` as the
+installation location but actually install to `./staging/usr/third_party`.
 
 This installation method isn't fool proof but if it fails on your system you
 will probably know exactly how to fix it or have no idea how to fix it. I'm
@@ -141,7 +149,7 @@ should be able to compile the program as follows:
 
     cc myexcel.c -o myexcel -lxlsxwriter
 
-In some environments, or if you changed the `INSTALL_DIR` location, you may
+In some environments, or if you changed the `PREFIX` location, you may
 have to provide explicit `include` and `lib` paths:
 
     cc myexcel.c -o myexcel -I/usr/local/include -L/usr/local/lib -lxlsxwriter

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,9 @@ ifdef V
 Q=
 endif
 
+DESTIDR ?=
+PREFIX  ?= /usr/local
+
 # Directory variables.
 OBJS_DIR    = .
 INC_DIR     = ../include

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,7 +94,7 @@ UNAME := $(shell uname)
 # Change make options on OS X.
 ifeq ($(UNAME), Darwin)
 LIBXLSXWRITER_SO = libxlsxwriter.dylib
-SOFLAGS = -dynamiclib $(FPIC) -install_name /usr/lib/$(LIBXLSXWRITER_SO)
+SOFLAGS = -dynamiclib $(FPIC) -install_name $(PREFIX)/lib/$(LIBXLSXWRITER_SO)
 endif
 
 # Check for MinGW/MinGW64/Cygwin environments.


### PR DESCRIPTION
`PREFIX` is the final location on the user's system. `DESTDIR` could
be staging directory for a package build, a chroot, etc. The
distinction is important because you don't want `DESTDIR` to end up
in paths compiled into the program, e.g. the location of a helpfile
or library.

(Applies only to the makefiles, not CMake)

Also use `PREFIX` for `-install_name`.

Resolves #216
Succeeds #209 