### PR TITLE
Use macro for printing to stderr

### DIFF
--- a/include/xlsxwriter/common.h
+++ b/include/xlsxwriter/common.h
@@ -33,6 +33,9 @@
 #define DEPRECATED(func, msg) func
 #endif
 
+#ifndef LXW_PRINT_ERR
+#define LXW_PRINT_ERR(...) fprintf(stderr, __VA_ARGS__);
+#endif
 /** Integer data type to represent a row value. Equivalent to `uint32_t`.
  *
  * The maximum row in Excel is 1,048,576.
@@ -224,7 +227,7 @@ enum lxw_custom_property_types {
 #define LXW_SCHEMA_CONTENT   LXW_SCHEMA_ROOT "/package/2006/content-types"
 
 #define LXW_ERROR(message)                      \
-    fprintf(stderr, "[ERROR][%s:%d]: " message "\n", __FILE__, __LINE__)
+    LXW_PRINT_ERR("[ERROR][%s:%d]: " message "\n", __FILE__, __LINE__)
 
 #define LXW_MEM_ERROR()                         \
     LXW_ERROR("Memory allocation failed.")
@@ -252,50 +255,50 @@ enum lxw_custom_property_types {
         return error;
 
 #define LXW_WARN(message)                       \
-    fprintf(stderr, "[WARNING]: " message "\n")
+    LXW_PRINT_ERR("[WARNING]: " message "\n")
 
 /* We can't use variadic macros here since we support ANSI C. */
 #define LXW_WARN_FORMAT(message)                \
-    fprintf(stderr, "[WARNING]: " message "\n")
+    LXW_PRINT_ERR("[WARNING]: " message "\n")
 
 #define LXW_WARN_FORMAT1(message, var)          \
-    fprintf(stderr, "[WARNING]: " message "\n", var)
+    LXW_PRINT_ERR("[WARNING]: " message "\n", var)
 
 #define LXW_WARN_FORMAT2(message, var1, var2)    \
-    fprintf(stderr, "[WARNING]: " message "\n", var1, var2)
+    LXW_PRINT_ERR("[WARNING]: " message "\n", var1, var2)
 
 /* Chart axis type checks. */
 #define LXW_WARN_CAT_AXIS_ONLY(function)                                   \
     if (!axis->is_category) {                                              \
-        fprintf(stderr, "[WARNING]: "                                      \
+        LXW_PRINT_ERR("[WARNING]: "                                      \
                 function "() is only valid for category axes\n");          \
        return;                                                             \
     }
 
 #define LXW_WARN_VALUE_AXIS_ONLY(function)                                 \
     if (!axis->is_value) {                                                 \
-        fprintf(stderr, "[WARNING]: "                                      \
+        LXW_PRINT_ERR("[WARNING]: "                                      \
                 function "() is only valid for value axes\n");             \
        return;                                                             \
     }
 
 #define LXW_WARN_DATE_AXIS_ONLY(function)                                  \
     if (!axis->is_date) {                                                  \
-        fprintf(stderr, "[WARNING]: "                                      \
+        LXW_PRINT_ERR("[WARNING]: "                                      \
                 function "() is only valid for date axes\n");              \
        return;                                                             \
     }
 
 #define LXW_WARN_CAT_AND_DATE_AXIS_ONLY(function)                          \
     if (!axis->is_category && !axis->is_date) {                            \
-        fprintf(stderr, "[WARNING]: "                                      \
+        LXW_PRINT_ERR("[WARNING]: "                                      \
                 function "() is only valid for category and date axes\n"); \
        return;                                                             \
     }
 
 #define LXW_WARN_VALUE_AND_DATE_AXIS_ONLY(function)                        \
     if (!axis->is_value && !axis->is_date) {                               \
-        fprintf(stderr, "[WARNING]: "                                      \
+        LXW_PRINT_ERR("[WARNING]: "                                      \
                 function "() is only valid for value and date axes\n");    \
        return;                                                             \
     }

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,7 +61,7 @@ CFLAGS += -DUSE_DOUBLE_FUNCTION
 endif
 
 # Flags passed to compiler.
-CFLAGS   += -g -O3 -Wall -Wextra -Wstrict-prototypes -pedantic -ansi
+CFLAGS   += -g -O3 -Wall -Wextra -Wstrict-prototypes -pedantic -std=c99
 
 # Fix for modified zconf.h on Gentoo.
 ifneq (,$(findstring gentoo, $(shell uname -sr)))

--- a/src/workbook.c
+++ b/src/workbook.c
@@ -1893,7 +1893,7 @@ workbook_close(lxw_workbook *self)
 
     /* If the packager fails it is generally due to a zip permission error. */
     if (packager == NULL) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Error creating '%s'. "
                 "System error = %s\n", self->filename, strerror(errno));
 
@@ -1909,28 +1909,28 @@ workbook_close(lxw_workbook *self)
 
     /* Error and non-error conditions fall through to the cleanup code. */
     if (error == LXW_ERROR_CREATING_TMPFILE) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Error creating tmpfile(s) to assemble '%s'. "
                 "System error = %s\n", self->filename, strerror(errno));
     }
 
     /* If LXW_ERROR_ZIP_FILE_OPERATION then errno is set by zip. */
     if (error == LXW_ERROR_ZIP_FILE_OPERATION) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Zip ZIP_ERRNO error while creating xlsx file '%s'. "
                 "System error = %s\n", self->filename, strerror(errno));
     }
 
     /* If LXW_ERROR_ZIP_PARAMETER_ERROR then errno is set by zip. */
     if (error == LXW_ERROR_ZIP_PARAMETER_ERROR) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Zip ZIP_PARAMERROR error while creating xlsx file '%s'. "
                 "System error = %s\n", self->filename, strerror(errno));
     }
 
     /* If LXW_ERROR_ZIP_BAD_ZIP_FILE then errno is set by zip. */
     if (error == LXW_ERROR_ZIP_BAD_ZIP_FILE) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Zip ZIP_BADZIPFILE error while creating xlsx file '%s'. "
                 "This may require the use_zip64 option for large files. "
                 "System error = %s\n", self->filename, strerror(errno));
@@ -1938,19 +1938,19 @@ workbook_close(lxw_workbook *self)
 
     /* If LXW_ERROR_ZIP_INTERNAL_ERROR then errno is set by zip. */
     if (error == LXW_ERROR_ZIP_INTERNAL_ERROR) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Zip ZIP_INTERNALERROR error while creating xlsx file '%s'. "
                 "System error = %s\n", self->filename, strerror(errno));
     }
 
     /* The next 2 error conditions don't set errno. */
     if (error == LXW_ERROR_ZIP_FILE_ADD) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Zip error adding file to xlsx file '%s'.\n", self->filename);
     }
 
     if (error == LXW_ERROR_ZIP_CLOSE) {
-        fprintf(stderr, "[ERROR] workbook_close(): "
+        LXW_PRINT_ERR("[ERROR] workbook_close(): "
                 "Zip error closing xlsx file '%s'.\n", self->filename);
     }
 


### PR DESCRIPTION
We use libxlswriter in R, but we are not supposed to use `fprintf(stderr, ...)` because applications and IDEs that embed the R interpreter ignore this. Instead the interpreter has a function `REprintf(...)` which packages call for text that the IDE or embedding application has to print to the user terminal.

So I would need some way to override the error-printing function, either at build time or at runtime. Here is a simple concept solution. This would allow me to compile libxlsxwriter with 

    CFLAGS += -DLXW_PRINT_ERR=REprintf

And thereby I get the desired behavior. Alternatively you could create some sort of set-callback, but that would be more involved.

The drawback of this approach I suppose is that variadic macros require c99, which is not a problem for me, but I don't know how else I would do this.

Thanks for you thoughts!
