### PR TITLE
Add image buffers without a temporary file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - NO_VALGRIND=1 USE_SYSTEM_MINIZIP=1   CFLAGS='-Werror'
   - NO_VALGRIND=1 USE_DOUBLE_FUNCTION=1  CFLAGS='-Werror'
   - NO_VALGRIND=1 USE_NO_MD5=1           CFLAGS='-Werror'
+  - NO_VALGRIND=1 USE_FMEMOPEN=1         CFLAGS='-Werror'
 
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ option(BUILD_EXAMPLES "Build libxlsxwriter examples" OFF)
 option(USE_SYSTEM_MINIZIP "Use system minizip installation" OFF)
 option(USE_STANDARD_TMPFILE "Use the C standard library's tmpfile()" OFF)
 option(USE_NO_MD5 "Build libxlsxwriter without third party MD5 lib" OFF)
+option(USE_FMEMOPEN "Use fmemopen() in place of some temporary files" OFF)
 option(IOAPI_NO_64 "Disable 64-bit filesystem support" OFF)
 
 if(MSVC)
@@ -146,6 +147,9 @@ if(USE_NO_MD5)
     list(APPEND LXW_PRIVATE_COMPILE_DEFINITIONS USE_NO_MD5)
 endif()
 
+if(USE_FMEMOPEN)
+    list(APPEND LXW_PRIVATE_COMPILE_DEFINITIONS USE_FMEMOPEN)
+endif()
 
 if(NOT BUILD_SHARED_LIBS)
     if(UNIX)

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,6 +60,11 @@ ifdef USE_DOUBLE_FUNCTION
 CFLAGS += -DUSE_DOUBLE_FUNCTION
 endif
 
+# Use fmemopen() to avoid creating certain temporary files
+ifdef USE_FMEMOPEN
+CFLAGS += -DUSE_FMEMOPEN
+endif
+
 # Flags passed to compiler.
 CFLAGS   += -g -O3 -Wall -Wextra -Wstrict-prototypes -pedantic -ansi
 

--- a/src/worksheet.c
+++ b/src/worksheet.c
@@ -7,6 +7,10 @@
  *
  */
 
+#ifdef USE_FMEMOPEN
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "xlsxwriter/xmlwriter.h"
 #include "xlsxwriter/worksheet.h"
 #include "xlsxwriter/format.h"
@@ -6301,9 +6305,14 @@ worksheet_insert_image_buffer_opt(lxw_worksheet *self,
         return LXW_ERROR_NULL_PARAMETER_IGNORED;
     }
 
-    /* Write the image buffer to a temporary file so we can read the
-     * dimensions like an ordinary file. */
+    /* Write the image buffer to a file (preferably in memory) so we can read
+     * the dimensions like an ordinary file. */
+#ifdef USE_FMEMOPEN
+    image_stream = fmemopen(NULL, image_size, "w+b");
+#else
     image_stream = lxw_tmpfile(self->tmpdir);
+#endif
+
     if (!image_stream)
         return LXW_ERROR_CREATING_TMPFILE;
 


### PR DESCRIPTION
Use `fmemopen` to create an in-memory `FILE *` for reading in image attributes. This avoids creating a separate temporary file for every image added to the worksheet.

Passing `NULL` as the first argument creates a buffer managed by `fmemopen`; I tried it the other way (passing in the buffer created elsewhere in `worksheet_insert_image_buffer_opt`) but it didn't seem to work. (Possibly a case of me misusing the API.)

According to the documentation, `fclose` will free the buffer, so I believe that this one line change is sufficient.

According to header comments on my platform (macOS 10.15) it looks like `fmemopen` is defined by POSIX.1-2008. We might need to wrap the feature in a #define to support older platforms. The change compiles, runs, and seems to work on macOS, but I haven't tested other platforms.

See #287 and https://pubs.opengroup.org/onlinepubs/9699919799/functions/fmemopen.html