### PR TITLE
Add missing zlib.h include, add library version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,13 @@ else()
 endif()
 
 SET(PROJECT_NAME "xlsxwriter" CACHE STRING "Optional project and binary name")
+
+# Soname
+# MAJOR is incremented when symbols are removed or changed in an incompatible way
+# MINOR is incremented when new symbols are added
+SET(LIB_VERSION_MAJOR 1)
+SET(LIB_VERSION_MINOR 0)
+
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 project(${PROJECT_NAME} C)
 enable_testing()
@@ -233,6 +240,7 @@ endif()
 set(LXW_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LXW_LIB_DIR "${LXW_PROJECT_DIR}/lib")
 add_library(${PROJECT_NAME} "")
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.0 SOVERSION ${LIB_VERSION_MAJOR})
 target_sources(${PROJECT_NAME}
     PRIVATE ${LXW_SOURCES}
     PUBLIC ${LXW_HEADERS}

--- a/src/packager.c
+++ b/src/packager.c
@@ -11,6 +11,7 @@
 #include "xlsxwriter/packager.h"
 #include "xlsxwriter/hash_table.h"
 #include "xlsxwriter/utility.h"
+#include <zlib.h>
 
 STATIC lxw_error _add_file_to_zip(lxw_packager *self, FILE * file,
                                   const char *filename);


### PR DESCRIPTION
Hi

Two patches I've applied while packaging libxlswriter for Fedora.

- I needed to include `zlib.h`, otherwise I get `Z_DEFAULT_COMPRESSION` not defined.
- It's good practice to version the library, so that dependent packages can keep track of which library version they are compatible with.