### PR TITLE
docs: fix simple typo, filemane -> filename

### DIFF
--- a/third_party/minizip/unzip.h
+++ b/third_party/minizip/unzip.h
@@ -306,7 +306,7 @@ extern int ZEXPORT unzGetCurrentFileInfo OF((unzFile file,
   Get Info about the current file
   if pfile_info!=NULL, the *pfile_info structure will contain somes info about
         the current file
-  if szFileName!=NULL, the filemane string will be copied in szFileName
+  if szFileName!=NULL, the filename string will be copied in szFileName
             (fileNameBufferSize is the size of the buffer)
   if extraField!=NULL, the extra field information will be copied in extraField
             (extraFieldBufferSize is the size of the buffer).


### PR DESCRIPTION
There is a small typo in third_party/minizip/unzip.h.

Should read `filename` rather than `filemane`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md