### PR TITLE
resolve issue 318

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,9 +94,9 @@ else()
     cmake_minimum_required(VERSION 3.1)
 endif()
 
-SET(PROJECT_NAME "xlsxwriter" CACHE STRING "Optional project and binary name")
+SET(XLSX_PROJECT_NAME "xlsxwriter" CACHE STRING "Optional project and binary name")
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-project(${PROJECT_NAME} C)
+project(${XLSX_PROJECT_NAME} C)
 enable_testing()
 
 # POLICY


### PR DESCRIPTION
The idea to resolve the feature request #318 simply adds a new cache variable and leafs the variable PROJECT_NAME untouched. Hence a user might change the projects name as before.

Please note, that cmake creates the variable PROJECT_NAME automatically and sets it to the last project() command. 