### PR TITLE
Add pkg-config files to the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,15 @@ if(MSVC AND USE_STATIC_MSVC_RUNTIME)
     endforeach()
 endif()
 
+# Configure pkg-config
+file(READ "include/xlsxwriter.h" ver)
+
+string(REGEX MATCH "VERSION .*\"\(.*\)\".*" _ ${ver})
+set(VERSION ${CMAKE_MATCH_1})
+set(PREFIX ${CMAKE_INSTALL_PREFIX})
+
+configure_file(dev/release/pkg-config.txt xlsxwriter.pc @ONLY)
+
 # INCLUDES
 # --------
 enable_language(CXX)
@@ -352,3 +361,4 @@ install(DIRECTORY include/xlsxwriter
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h"
 )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xlsxwriter.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ PREFIX  ?= /usr/local
 PYTEST ?= py.test
 PYTESTFILES ?= test
 
+VERSION = $(shell sed -n -e '/VERSION "/s/.*"\(.*\)".*/\1/p' < include/xlsxwriter.h)
+
 .PHONY: docs tags examples
 
 # Build the libs.
@@ -61,6 +63,7 @@ clean :
 	$(Q)rm -rf test/functional/__pycache__
 	$(Q)rm -f  test/functional/*.pyc
 	$(Q)rm -f  lib/*
+	$(Q)rm -f  xlsxwriter.pc
 ifndef USE_SYSTEM_MINIZIP
 	$(Q)$(MAKE) clean -C third_party/minizip
 endif
@@ -149,11 +152,14 @@ install: all
 	$(Q)cp -R include/* $(DESTDIR)$(PREFIX)/include
 	$(Q)mkdir -p        $(DESTDIR)$(PREFIX)/lib
 	$(Q)cp lib/*        $(DESTDIR)$(PREFIX)/lib
+	$(Q)mkdir -p        $(DESTDIR)$(PREFIX)/lib/pkgconfig
+	$(Q)sed -e          's|@PREFIX@|$(PREFIX)|g'  -e 's|@VERSION@|$(VERSION)|g' dev/release/pkg-config.txt > $(DESTDIR)$(PREFIX)/lib/pkgconfig/xlsxwriter.pc
 
 # Simpler minded uninstall.
 uninstall:
 	$(Q)rm -rf $(DESTDIR)$(PREFIX)/include/xlsxwriter*
 	$(Q)rm     $(DESTDIR)$(PREFIX)/lib/libxlsxwriter.*
+	$(Q)rm     $(DESTDIR)$(PREFIX)/lib/pkgconfig/xlsxwriter.pc
 
 # Strip the lib files.
 strip:

--- a/dev/release/pkg-config.txt
+++ b/dev/release/pkg-config.txt
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: libxlsxwriter
+Description: A C library for creating Excel XLSX files
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lxlsxwriter


### PR DESCRIPTION
Fixes: https://github.com/jmcnamara/libxlsxwriter/issues/132

This PR adds pkg-config files to Makefile and CMake builds. I know that #132 was closed because the simplicity of linking libxlsxwriter doesn't require pkg-config. However, the reason I'm doing this is that I'm writing a Swift binding to libxlsxwriter and SwiftPM has native support for pkg-config which would make it simpler to build in macOS and Linux. Even though there are other workarounds to this problem, I find using pkg-config the most convenient solution.