### PR TITLE
fix: resolve issue 318 or 146

### DIFF
--- a/src/chart.c
+++ b/src/chart.c
@@ -79,7 +79,9 @@ _chart_free_font(lxw_chart_font *font)
         return;
 
     free(font->name);
+    font->name=NULL;
     free(font);
+    font=NULL;
 }
 
 STATIC void

--- a/src/chart.c
+++ b/src/chart.c
@@ -869,7 +869,7 @@ _chart_write_a_def_rpr(lxw_chart *self, lxw_chart_font *font)
         if (font->size > 0.0)
             LXW_PUSH_ATTRIBUTES_DBL("sz", font->size);
 
-        if (use_font_default || font )
+        if (use_font_default || !font->bold)
             LXW_PUSH_ATTRIBUTES_INT("b", font->bold & 0x1);
 
         if (use_font_default || font->italic)

--- a/src/chart.c
+++ b/src/chart.c
@@ -869,7 +869,7 @@ _chart_write_a_def_rpr(lxw_chart *self, lxw_chart_font *font)
         if (font->size > 0.0)
             LXW_PUSH_ATTRIBUTES_DBL("sz", font->size);
 
-        if (use_font_default || font->bold)
+        if (use_font_default || font)
             LXW_PUSH_ATTRIBUTES_INT("b", font->bold & 0x1);
 
         if (use_font_default || font->italic)

--- a/src/chart.c
+++ b/src/chart.c
@@ -869,7 +869,7 @@ _chart_write_a_def_rpr(lxw_chart *self, lxw_chart_font *font)
         if (font->size > 0.0)
             LXW_PUSH_ATTRIBUTES_DBL("sz", font->size);
 
-        if (use_font_default || font)
+        if (use_font_default || font )
             LXW_PUSH_ATTRIBUTES_INT("b", font->bold & 0x1);
 
         if (use_font_default || font->italic)

--- a/src/chart.c
+++ b/src/chart.c
@@ -869,7 +869,7 @@ _chart_write_a_def_rpr(lxw_chart *self, lxw_chart_font *font)
         if (font->size > 0.0)
             LXW_PUSH_ATTRIBUTES_DBL("sz", font->size);
 
-        if (use_font_default || !font->bold)
+        if (use_font_default || font->bold|| self->title.font)
             LXW_PUSH_ATTRIBUTES_INT("b", font->bold & 0x1);
 
         if (use_font_default || font->italic)


### PR DESCRIPTION
  After the font pointer is released, it will continue to be used later, which affects the problem. After the font name is initialized, the font bold will always take effect. After the release, the font pointer can be left blank to solve the problem.

Log: Fix the problem that the font thickness setting is invalid when the font name is initialized