### PR TITLE
Theoretical Fix issue with BoringSSL-GRPC via update to the podspec

### DIFF
--- a/libxlsxwriter.podspec
+++ b/libxlsxwriter.podspec
@@ -39,9 +39,7 @@ Pod::Spec.new do |s|
 
   s.source                = { :git => "https://github.com/jmcnamara/libxlsxwriter.git", :tag => "RELEASE_" + s.version.to_s }
   s.source_files          = "src/**/*.c", "third_party/**/{zip.c,ioapi.c,tmpfileplus.c,md5.c}", "include/**/*.h"
-  s.preserve_paths = [
-    'third_party/**/*.h',
-  ]
+  s.preserve_paths        = [ 'third_party/**/*.h' ]
   s.header_dir            = "xlsxwriter"
   s.header_mappings_dir   = "include"
   s.library               = "z"

--- a/libxlsxwriter.podspec
+++ b/libxlsxwriter.podspec
@@ -37,9 +37,11 @@ Pod::Spec.new do |s|
   s.license               = "FreeBSD"
   s.author                = { "John McNamara" => "jmcnamara@cpan.org" }
 
-  s.source                = { :git => "https://github.com/jmcnamara/libxlsxwriter.git", :tag => "RELEASE_" + s.version.to_s }
+  s.source                = { :git => "https://github.com/52inc/libxlsxwriter", :tag => "RELEASE_" + s.version.to_s }
   s.source_files          = "src/**/*.c", "third_party/**/{zip.c,ioapi.c,tmpfileplus.c,md5.c}", "include/**/*.h"
-
+  s.preserve_paths = [
+    'third_party/**/.h',
+  ]
   s.header_dir            = "xlsxwriter"
   s.header_mappings_dir   = "include"
   s.library               = "z"

--- a/libxlsxwriter.podspec
+++ b/libxlsxwriter.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   s.license               = "FreeBSD"
   s.author                = { "John McNamara" => "jmcnamara@cpan.org" }
 
-  s.source                = { :git => "https://github.com/52inc/libxlsxwriter", :tag => "RELEASE_" + s.version.to_s }
+  s.source                = { :git => "https://github.com/jmcnamara/libxlsxwriter.git", :tag => "RELEASE_" + s.version.to_s }
   s.source_files          = "src/**/*.c", "third_party/**/{zip.c,ioapi.c,tmpfileplus.c,md5.c}", "include/**/*.h"
   s.preserve_paths = [
     'third_party/**/*.h',

--- a/libxlsxwriter.podspec
+++ b/libxlsxwriter.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.source                = { :git => "https://github.com/52inc/libxlsxwriter", :tag => "RELEASE_" + s.version.to_s }
   s.source_files          = "src/**/*.c", "third_party/**/{zip.c,ioapi.c,tmpfileplus.c,md5.c}", "include/**/*.h"
   s.preserve_paths = [
-    'third_party/**/.h',
+    'third_party/**/*.h',
   ]
   s.header_dir            = "xlsxwriter"
   s.header_mappings_dir   = "include"


### PR DESCRIPTION
Fix to issue #342 

Taking note from how Firebase uses `preserve_path` https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseFirestore.podspec#L54 and the issue created on the CocoaPods repo https://github.com/CocoaPods/CocoaPods/issues/10772. 

This appears to fix my issue and allows my applications to build and the LibXlsxWriterSwiftSample to build with 'BoringSSL-GRPC'.

The LibXlsxWriterSwiftSample uses the following pod file to run with `BoringSSL-GRPC`:
```
# Uncomment the next line to define a global platform for your project
platform :ios, '13.0'

target 'LibXlsxWriterSwiftSample' do
  # Comment the next line if you don't want to use dynamic frameworks
  use_frameworks!

  # Pods for LibXlsxWriterSwiftSample
  pod 'libxlsxwriter', :git => 'https://github.com/52inc/libxlsxwriter.git'
  pod 'Sourceful', '~> 0.2' #Only present for synzax highlighting
  pod 'BoringSSL-GRPC'
end
```