### PR TITLE
Don't use LDLFAGS when building these .so files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -177,7 +177,7 @@ test_compile : $(OBJS)
 	$(Q)$(CC) -I$(INC_DIR) $(CFLAGS) $(CXXFLAGS) $(TARGET_ARCH) $(GCOV) -c $<
 
 %.so : %.c $(HDRS)
-	$(Q)$(CC) $(FPIC) -I$(INC_DIR) $(LDFLAGS) $(CFLAGS) $(CXXFLAGS) $(TARGET_ARCH) $(GCOV) -c $< -o $@
+	$(Q)$(CC) $(FPIC) -I$(INC_DIR) $(CFLAGS) $(CXXFLAGS) $(TARGET_ARCH) $(GCOV) -c $< -o $@
 
 %.to : %.c $(HDRS)
 	$(Q)$(CC) -g $(OPT_LEVEL) -DTESTING -I$(INC_DIR) $(CFLAGS) $(CXXFLAGS) $(GCOV) -c $< -o $@


### PR DESCRIPTION
This Makefile builds 3 versions of each object: a regular one, one
usable for linking into a shared object, and one for tests, each with
different flags. They are named .o, .so, and .to respectively -- but
these .so files are regular object files, NOT shared libraries.

Hence, they shouldn't be built with ${LDFLAGS} because no linking is
happening here, they're just regular object files compiled with -c.

Passing on LDFLAGS here anyway can cause warnings or errors like this:

    $ make V=1 LDFLAGS=-Wl,-rpath,/opt/pkg/lib
    ...
    cc -fPIC -I../include -Wl,-rpath,/opt/pkg/lib -g -O3 -Wall -Wextra -Wstrict-prototypes -pedantic -ansi    -c app.c -o app.so
    clang: warning: -Wl,-rpath,/opt/pkg/lib: 'linker' input unused [-Wunused-command-line-argument]
    ...

(Of course the actual linking into libxlsxwriter.so or .dylib still
uses LDFLAGS.)