### PR TITLE
Support user-supplied config.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+# Optional user variable declarations
+-include config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,6 +5,8 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+-include ../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,6 +5,8 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+-include ../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,8 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+-include ../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/test/functional/src/Makefile
+++ b/test/functional/src/Makefile
@@ -5,6 +5,8 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+-include ../../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -5,6 +5,8 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+-include ../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/test/unit/Makefile.unit
+++ b/test/unit/Makefile.unit
@@ -5,6 +5,8 @@
 # Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
 #
 
+-include ../../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/third_party/dtoa/Makefile
+++ b/third_party/dtoa/Makefile
@@ -3,6 +3,8 @@
 # Simplied Makefile to build the emyg_dtoa library for libxlsxwriter.
 #
 
+-include ../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/third_party/md5/Makefile
+++ b/third_party/md5/Makefile
@@ -3,6 +3,8 @@
 # Simplied Makefile to build the openwall md5 library for libxlsxwriter.
 #
 
+-include ../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/third_party/minizip/Makefile
+++ b/third_party/minizip/Makefile
@@ -3,6 +3,8 @@
 # Simplied Makefile to build the minizip objects for the libxlsxwriter library.
 #
 
+-include ../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V

--- a/third_party/tmpfileplus/Makefile
+++ b/third_party/tmpfileplus/Makefile
@@ -3,6 +3,8 @@
 # Simplied Makefile to build tmpfileplus for the libxlsxwriter library.
 #
 
+-include ../../config.mk
+
 # Keep the output quiet by default.
 Q=@
 ifdef V


### PR DESCRIPTION
Users and developers may have to make some `make` configuration changes
to suit the local environment, for example for setting up library search
paths. To avoid having to type arguments to `make` every time temporary local
changes may be made to Makefiles but this presents two problems:

 1. There are many Makefiles used in this project that must be edited.
 2. It clutters the git status and makes it easy to accidentally commit
    such a local Makefile change.

This commit adds includes for an optional, top level `config.mk` for
local changes, ignored by version control.