### PR TITLE
Respect LDFLAGS when linking tests

### DIFF
--- a/test/functional/src/Makefile
+++ b/test/functional/src/Makefile
@@ -61,7 +61,7 @@ clean :
 
 # Executable targets.
 %: %.c $(LIBXLSXWRITER)
-	$(Q)$(CC) -I$(INC_DIR) $(CFLAGS) $(GCOV) $< -o $@ $(LIBS)
+	$(Q)$(CC) -I$(INC_DIR) $(CFLAGS) $(LDFLAGS) $(GCOV) $< -o $@ $(LIBS)
 
 test_valgrind: all
 	$(Q)$(foreach exe,$(EXES),valgrind -q --error-exitcode=1 --leak-check=full ./$(exe) || exit;)

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -106,7 +106,7 @@ clean :
 # Builds the tests.
 #
 test_all : test_all.o $(OBJS) $(LIBS_A)
-	$(Q)$(CC) $(CFLAGS) -I$(INC_DIR) -o $@ $^ $(LIBS_O)
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -I$(INC_DIR) -o $@ $^ $(LIBS_O)
 
 
 ###############################################################################

--- a/test/unit/Makefile.unit
+++ b/test/unit/Makefile.unit
@@ -53,7 +53,7 @@ clean :
 	$(Q)$(CC) -I$(INC_DIR) $(CFLAGS) -c $<
 
 test_%: main.o test_%.o $(LIBS_A)
-	$(Q)$(CC) $(CFLAGS) -o $@ $^ $(LIBS_O)
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS_O)
 
 # Link all the tests into one test executable.
 test_all : main.o $(OBJS) $(LIBS_A)


### PR DESCRIPTION
Otherwise it's not possible to link e.g. system minizip if it's outside
the default search paths.