### PR TITLE
Link minizip and crypto in C++ test if required

### DIFF
--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -24,6 +24,14 @@ EXES = $(patsubst %.cpp,%,$(SRCS))
 LIBXLSXWRITER = ../../src/libxlsxwriter.a
 LIBS = $(LIBXLSXWRITER) -lz
 
+ifdef USE_SYSTEM_MINIZIP
+LIBS += -lminizip
+endif
+
+ifdef USE_OPENSSL_MD5
+LIBS += -lcrypto
+endif
+
 all : $(LIBXLSXWRITER) $(EXES)
 
 $(LIBXLSXWRITER):


### PR DESCRIPTION
Setting USE_SYSTEM_MINIZIP and USE_OPENSSL_MD5 causes minizip and crypto
respectively to become dependencies of libxlsxwriter, hence then they
need to be linked in the C++ test, too.