### PR TITLE
Respect LDFLAGS in test/cpp/Makefile

### DIFF
--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -34,4 +34,4 @@ clean :
 
 # Executable targets.
 %: %.cpp $(LIBXLSXWRITER)
-	$(Q)$(CXX) -I$(INC_DIR) $(CXXFLAGS) $< -o $@ $(LIBS)
+	$(Q)$(CXX) -I$(INC_DIR) $(CXXFLAGS) $(LDFLAGS) $< -o $@ $(LIBS)


### PR DESCRIPTION
E.g. so libraries are found when using a third-party package manager.