### PR TITLE
Add buffer support

### DIFF
--- a/.github/workflows/cmake_actions.yml
+++ b/.github/workflows/cmake_actions.yml
@@ -12,7 +12,7 @@ jobs:
         cmake_flags: ["",
                       "-DBUILD_EXAMPLES=ON       -DBUILD_TESTS=ON",
                       "-DUSE_DTOA_LIBRARY=ON     -DBUILD_TESTS=ON",
-                      "-DUSE_FMEMOPEN=ON         -DBUILD_TESTS=ON",
+                      "-DUSE_MEM_FILE=ON         -DBUILD_TESTS=ON",
                       "-DUSE_NO_MD5=ON           -DBUILD_TESTS=ON",
                       "-DUSE_OPENSSL_MD5=ON      -DBUILD_TESTS=ON",
                       "-DUSE_STANDARD_TMPFILE=ON -DBUILD_TESTS=ON",

--- a/.github/workflows/make_actions.yml
+++ b/.github/workflows/make_actions.yml
@@ -15,7 +15,7 @@ jobs:
                      "USE_DTOA_LIBRARY=1",
                      "USE_NO_MD5=1",
                      "USE_OPENSSL_MD5=1",
-                     "USE_FMEMOPEN=1"]
+                     "USE_MEM_FILE=1"]
     runs-on: ubuntu-latest
     env:
       CC:     ${{ matrix.cc }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ option(USE_SYSTEM_MINIZIP "Use system minizip installation" OFF)
 option(USE_STANDARD_TMPFILE "Use the C standard library's tmpfile()" OFF)
 option(USE_NO_MD5 "Build libxlsxwriter without third party MD5 lib" OFF)
 option(USE_OPENSSL_MD5 "Build libxlsxwriter with the OpenSSL MD5 lib" OFF)
-option(USE_FMEMOPEN "Use fmemopen() in place of some temporary files" OFF)
+option(USE_MEM_FILE "Use fmemopen()/open_memstream() in place of temporary files" OFF)
 option(IOAPI_NO_64 "Disable 64-bit filesystem support" OFF)
 option(USE_DTOA_LIBRARY "Use the locale independent third party Milo Yip DTOA library" OFF)
 
@@ -165,7 +165,7 @@ if(USE_OPENSSL_MD5)
     list(APPEND LXW_PRIVATE_COMPILE_DEFINITIONS USE_OPENSSL_MD5)
 endif()
 
-if(USE_FMEMOPEN)
+if(USE_MEM_FILE OR USE_FMEMOPEN)
     list(APPEND LXW_PRIVATE_COMPILE_DEFINITIONS USE_FMEMOPEN)
 endif()
 

--- a/docs/src/getting_started.dox
+++ b/docs/src/getting_started.dox
@@ -541,7 +541,7 @@ The following are various compilation targets and options for both build systems
 | `examples`               | `-DBUILD_EXAMPLES=ON`                      | Build the example                                     |
 | `test`                   | `-DBUILD_TESTS=ON`                         | Build the tests                                       |
 | `USE_DTOA_LIBRARY=1`     | `-DUSE_DTOA_LIBRARY=ON`                    | Use alternative double in sprintf                     |
-| `USE_FMEMOPEN=1`         | `-DUSE_FMEMOPEN=ON`                        | Use fmemopen()/open_memstream() instead of temp files |
+| `USE_MEM_FILE=1`         | `-DUSE_MEM_FILE=ON`                        | Use fmemopen()/open_memstream() instead of temp files |
 | `USE_OPENSSL_MD5=1`      | `-DUSE_OPENSSL_MD5=ON`                     | Use OpenSSL for MD5 digest                            |
 | `USE_NO_MD5=1`           | `-DUSE_NO_MD5=ON`                          | Don't use a MD5 digest                                |
 | `USE_SYSTEM_MINIZIP=1`   | `-DUSE_SYSTEM_MINIZIP=ON`                  | Use system minzip library                             |
@@ -573,7 +573,7 @@ Each of the options are explained below:
 
 - `USE_DTOA_LIBRARY`: See @ref gsg_dtoa "using a double formatting library".
 
-- `USE_FMEMOPEN`: Use fmemopen()/open_memstream() instead of temporary files.
+- `USE_MEM_FILE`: Use fmemopen()/open_memstream() instead of temporary files.
   This option isn't on by default since it isn't supported on Windows.
 
 - `USE_OPENSSL_MD5`: Uses OpenSSL to provide a MD5 digest of image files in

--- a/docs/src/getting_started.dox
+++ b/docs/src/getting_started.dox
@@ -165,7 +165,7 @@ have to provide explicit `include` and `lib` paths:
     cc myexcel.c -o myexcel -I/usr/local/include -L/usr/local/lib -lxlsxwriter
 
 You can also use
-[pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) 
+[pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 (after installation of the library) to automatically determine the required
 arguments and paths:
 
@@ -536,21 +536,21 @@ with larger CMake builds. In particular it enables building on Windows.
 
 The following are various compilation targets and options for both build systems:
 
-| Make                     | CMake                                      | Description                         |
-| :----------------------- | :----------------------------------------- | :---------------------------------- |
-| `examples`               | `-DBUILD_EXAMPLES=ON`                      | Build the example                   |
-| `test`                   | `-DBUILD_TESTS=ON`                         | Build the tests                     |
-| `USE_DTOA_LIBRARY=1`     | `-DUSE_DTOA_LIBRARY=ON`                    | Use alternative double in sprintf   |
-| `USE_FMEMOPEN=1`         | `-DUSE_FMEMOPEN=ON`                        | Use fmemopen() for temp image files |
-| `USE_OPENSSL_MD5=1`      | `-DUSE_OPENSSL_MD5=ON`                     | Use OpenSSL for MD5 digest          |
-| `USE_NO_MD5=1`           | `-DUSE_NO_MD5=ON`                          | Don't use a MD5 digest              |
-| `USE_SYSTEM_MINIZIP=1`   | `-DUSE_SYSTEM_MINIZIP=ON`                  | Use system minzip library           |
-| `USE_STANDARD_TMPFILE=1` | `-DUSE_STANDARD_TMPFILE=ON`                | Use system tmpfile() function       |
-| `USE_BIG_ENDIAN=1`       | `-DUSE_BIG_ENDIAN=ON`                      | Build on big endian systems         |
-| `universal_binary`       | `-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"` | Create a macOS "Universal Binary"   |
-|                          | `-DBUILD_SHARED_LIBS=ON`                   | Build shared library (default on)   |
-|                          | `-DUSE_STATIC_MSVC_RUNTIME=ON`             | Use static msvc runtime library     |
-|                          | `-DCMAKE_BUILD_TYPE=Release`               | Set the build type.                 |
+| Make                     | CMake                                      | Description                                           |
+| :----------------------- | :----------------------------------------- | :---------------------------------------------------- |
+| `examples`               | `-DBUILD_EXAMPLES=ON`                      | Build the example                                     |
+| `test`                   | `-DBUILD_TESTS=ON`                         | Build the tests                                       |
+| `USE_DTOA_LIBRARY=1`     | `-DUSE_DTOA_LIBRARY=ON`                    | Use alternative double in sprintf                     |
+| `USE_FMEMOPEN=1`         | `-DUSE_FMEMOPEN=ON`                        | Use fmemopen()/open_memstream() instead of temp files |
+| `USE_OPENSSL_MD5=1`      | `-DUSE_OPENSSL_MD5=ON`                     | Use OpenSSL for MD5 digest                            |
+| `USE_NO_MD5=1`           | `-DUSE_NO_MD5=ON`                          | Don't use a MD5 digest                                |
+| `USE_SYSTEM_MINIZIP=1`   | `-DUSE_SYSTEM_MINIZIP=ON`                  | Use system minzip library                             |
+| `USE_STANDARD_TMPFILE=1` | `-DUSE_STANDARD_TMPFILE=ON`                | Use system tmpfile() function                         |
+| `USE_BIG_ENDIAN=1`       | `-DUSE_BIG_ENDIAN=ON`                      | Build on big endian systems                           |
+| `universal_binary`       | `-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"` | Create a macOS "Universal Binary"                     |
+|                          | `-DBUILD_SHARED_LIBS=ON`                   | Build shared library (default on)                     |
+|                          | `-DUSE_STATIC_MSVC_RUNTIME=ON`             | Use static msvc runtime library                       |
+|                          | `-DCMAKE_BUILD_TYPE=Release`               | Set the build type.                                   |
 
 
 The compilation options would be used as follows:
@@ -573,11 +573,8 @@ Each of the options are explained below:
 
 - `USE_DTOA_LIBRARY`: See @ref gsg_dtoa "using a double formatting library".
 
-- `USE_FMEMOPEN`: When inserting an image from a buffer using
-  `worksheet_insert_image_buffer()` libxlsxwriter writes the buffer to a
-  temporary file before processing it. In order to avoid this small overhead
-  you can use this option to invoke `fmemopen()` instead. This option isn't on
-  by default since it isn't supported on Windows.
+- `USE_FMEMOPEN`: Use fmemopen()/open_memstream() instead of temporary files.
+  This option isn't on by default since it isn't supported on Windows.
 
 - `USE_OPENSSL_MD5`: Uses OpenSSL to provide a MD5 digest of image files in
   order to avoid storing duplicates. See @ref gsg_md5.

--- a/examples/constant_memory.c
+++ b/examples/constant_memory.c
@@ -18,7 +18,9 @@ int main() {
     /* Set the worksheet options. */
     lxw_workbook_options options = {.constant_memory = LXW_TRUE,
                                     .tmpdir = NULL,
-                                    .use_zip64 = LXW_FALSE};
+                                    .use_zip64 = LXW_FALSE,
+                                    .output_buffer = NULL,
+                                    .output_buffer_size = NULL};
 
     /* Create a new workbook with options. */
     lxw_workbook  *workbook  = workbook_new_opt("constant_memory.xlsx", &options);

--- a/examples/output_buffer.c
+++ b/examples/output_buffer.c
@@ -1,0 +1,39 @@
+/*
+ * Example of using libxlsxwriter for writing a workbook file to a buffer.
+ *
+ * Copyright 2014-2021, John McNamara, jmcnamara@cpan.org
+ *
+ */
+
+#include <stdio.h>
+
+#include "xlsxwriter.h"
+
+int main() {
+    char *output_buffer;
+    size_t output_buffer_size;
+
+    /* Set the worksheet options. */
+    lxw_workbook_options options = {.output_buffer = &output_buffer,
+                                    .output_buffer_size = &output_buffer_size,
+                                    .constant_memory = LXW_FALSE,
+                                    .tmpdir = NULL,
+                                    .use_zip64 = LXW_FALSE};
+
+    /* Create a new workbook with options. */
+    lxw_workbook  *workbook  = workbook_new_opt(NULL, &options);
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
+
+    worksheet_write_string(worksheet, 0, 0, "Hello", NULL);
+    worksheet_write_number(worksheet, 1, 0, 123,     NULL);
+
+    lxw_error error = workbook_close(workbook);
+
+    if (error)
+        return error;
+
+    /* Write the XLSX file to standard output. */
+    fwrite(output_buffer, output_buffer_size, 1, stdout);
+
+    return ferror(stdout);
+}

--- a/include/xlsxwriter/packager.h
+++ b/include/xlsxwriter/packager.h
@@ -62,10 +62,12 @@ typedef struct lxw_packager {
     lxw_workbook *workbook;
 
     size_t buffer_size;
+    size_t output_buffer_size;
     zipFile zipfile;
     zip_fileinfo zipfile_info;
     char *filename;
     char *buffer;
+    char *output_buffer;
     char *tmpdir;
     uint8_t use_zip64;
 

--- a/include/xlsxwriter/utility.h
+++ b/include/xlsxwriter/utility.h
@@ -233,7 +233,7 @@ void lxw_str_tolower(char *str);
 #endif
 
 FILE *lxw_tmpfile(char *tmpdir);
-FILE *lxw_memstream(char **buf, size_t *size, char *tmpdir);
+FILE *lxw_get_filehandle(char **buf, size_t *size, char *tmpdir);
 FILE *lxw_fopen(const char *filename, const char *mode);
 
 /* Use the third party dtoa function to avoid locale issues with sprintf

--- a/include/xlsxwriter/utility.h
+++ b/include/xlsxwriter/utility.h
@@ -233,6 +233,7 @@ void lxw_str_tolower(char *str);
 #endif
 
 FILE *lxw_tmpfile(char *tmpdir);
+FILE *lxw_memstream(char **buf, size_t *size, char *tmpdir);
 FILE *lxw_fopen(const char *filename, const char *mode);
 
 /* Use the third party dtoa function to avoid locale issues with sprintf

--- a/include/xlsxwriter/workbook.h
+++ b/include/xlsxwriter/workbook.h
@@ -243,6 +243,13 @@ typedef struct lxw_doc_properties {
  *   for more information. This option is off by default.
  *
  *   [zip64_wiki]: https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64
+
+ * - `output_buffer`: Output to a buffer instead of a file. The buffer must be
+ *   freed manually by calling free(). This option is required when filename is
+ *   NULL.
+ *
+ * - `output_buffer_size`: Used with output_buffer to get the size of the
+ *   created buffer. This option is required when filename is NULL.
  *
  * @note In `constant_memory` mode each row of in-memory data is written to
  * disk and then freed when a new row is started via one of the
@@ -268,6 +275,11 @@ typedef struct lxw_workbook_options {
     /** Allow ZIP64 extensions when creating the xlsx file zip container. */
     uint8_t use_zip64;
 
+    /** Output buffer to use instead of writing to a file */
+    char **output_buffer;
+
+    /** Used with output_buffer to get the size of the created buffer */
+    size_t *output_buffer_size;
 } lxw_workbook_options;
 
 /**
@@ -376,7 +388,9 @@ lxw_workbook *workbook_new(const char *filename);
  * @code
  *    lxw_workbook_options options = {.constant_memory = LXW_TRUE,
  *                                    .tmpdir = "C:\\Temp",
- *                                    .use_zip64 = LXW_FALSE};
+ *                                    .use_zip64 = LXW_FALSE,
+ *                                    .output_buffer = NULL,
+ *                                    .output_buffer_size = NULL};
  *
  *    lxw_workbook  *workbook  = workbook_new_opt("filename.xlsx", &options);
  * @endcode

--- a/include/xlsxwriter/workbook.h
+++ b/include/xlsxwriter/workbook.h
@@ -245,11 +245,11 @@ typedef struct lxw_doc_properties {
  *   [zip64_wiki]: https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64
 
  * - `output_buffer`: Output to a buffer instead of a file. The buffer must be
- *   freed manually by calling free(). This option is required when filename is
- *   NULL.
+ *   freed manually by calling free(). This option can only be used if filename
+ *   is NULL.
  *
  * - `output_buffer_size`: Used with output_buffer to get the size of the
- *   created buffer. This option is required when filename is NULL.
+ *   created buffer. This option can only be used if filename is NULL.
  *
  * @note In `constant_memory` mode each row of in-memory data is written to
  * disk and then freed when a new row is started via one of the

--- a/include/xlsxwriter/worksheet.h
+++ b/include/xlsxwriter/worksheet.h
@@ -2108,6 +2108,7 @@ typedef struct lxw_worksheet {
 
     FILE *file;
     FILE *optimize_tmpfile;
+    char *optimize_buffer;
     struct lxw_table_rows *table;
     struct lxw_table_rows *hyperlinks;
     struct lxw_table_rows *comments;

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,6 +73,10 @@ DTOA_LIB_SO  = $(DTOA_LIB_DIR)/emyg_dtoa.so
 endif
 
 # Use fmemopen()/open_memstream() to avoid creating temporary files
+ifdef USE_MEM_FILE
+USE_FMEMOPEN = 1
+endif
+
 ifdef USE_FMEMOPEN
 CFLAGS += -DUSE_FMEMOPEN
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ DTOA_LIB_OBJ = $(DTOA_LIB_DIR)/emyg_dtoa.o
 DTOA_LIB_SO  = $(DTOA_LIB_DIR)/emyg_dtoa.so
 endif
 
-# Use fmemopen() to avoid creating certain temporary files
+# Use fmemopen()/open_memstream() to avoid creating temporary files
 ifdef USE_FMEMOPEN
 CFLAGS += -DUSE_FMEMOPEN
 endif

--- a/src/packager.c
+++ b/src/packager.c
@@ -188,7 +188,8 @@ _write_workbook_file(lxw_packager *self)
     lxw_workbook *workbook = self->workbook;
     lxw_error err;
 
-    workbook->file = lxw_tmpfile(self->tmpdir);
+    char *buf = NULL;
+    workbook->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!workbook->file)
         return LXW_ERROR_CREATING_TMPFILE;
 
@@ -196,6 +197,7 @@ _write_workbook_file(lxw_packager *self)
 
     err = _add_file_to_zip(self, workbook->file, "xl/workbook.xml");
     fclose(workbook->file);
+    free(buf);
     RETURN_ON_ERROR(err);
 
     return LXW_NO_ERROR;
@@ -211,6 +213,7 @@ _write_worksheet_files(lxw_packager *self)
     lxw_sheet *sheet;
     lxw_worksheet *worksheet;
     char sheetname[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
     lxw_error err;
 
@@ -226,7 +229,7 @@ _write_worksheet_files(lxw_packager *self)
         if (worksheet->optimize_row)
             lxw_worksheet_write_single_row(worksheet);
 
-        worksheet->file = lxw_tmpfile(self->tmpdir);
+        worksheet->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!worksheet->file)
             return LXW_ERROR_CREATING_TMPFILE;
 
@@ -234,6 +237,7 @@ _write_worksheet_files(lxw_packager *self)
 
         err = _add_file_to_zip(self, worksheet->file, sheetname);
         fclose(worksheet->file);
+        free(buf);
         RETURN_ON_ERROR(err);
     }
 
@@ -250,6 +254,7 @@ _write_chartsheet_files(lxw_packager *self)
     lxw_sheet *sheet;
     lxw_chartsheet *chartsheet;
     char sheetname[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
     lxw_error err;
 
@@ -262,7 +267,7 @@ _write_chartsheet_files(lxw_packager *self)
         lxw_snprintf(sheetname, LXW_FILENAME_LENGTH,
                      "xl/chartsheets/sheet%d.xml", index++);
 
-        chartsheet->file = lxw_tmpfile(self->tmpdir);
+        chartsheet->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!chartsheet->file)
             return LXW_ERROR_CREATING_TMPFILE;
 
@@ -270,6 +275,7 @@ _write_chartsheet_files(lxw_packager *self)
 
         err = _add_file_to_zip(self, chartsheet->file, sheetname);
         fclose(chartsheet->file);
+        free(buf);
         RETURN_ON_ERROR(err);
     }
 
@@ -375,6 +381,7 @@ _write_chart_files(lxw_packager *self)
     lxw_workbook *workbook = self->workbook;
     lxw_chart *chart;
     char sheetname[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
     lxw_error err;
 
@@ -383,7 +390,7 @@ _write_chart_files(lxw_packager *self)
         lxw_snprintf(sheetname, LXW_FILENAME_LENGTH,
                      "xl/charts/chart%d.xml", index++);
 
-        chart->file = lxw_tmpfile(self->tmpdir);
+        chart->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!chart->file)
             return LXW_ERROR_CREATING_TMPFILE;
 
@@ -391,6 +398,7 @@ _write_chart_files(lxw_packager *self)
 
         err = _add_file_to_zip(self, chart->file, sheetname);
         fclose(chart->file);
+        free(buf);
         RETURN_ON_ERROR(err);
     }
 
@@ -425,6 +433,7 @@ _write_drawing_files(lxw_packager *self)
     lxw_worksheet *worksheet;
     lxw_drawing *drawing;
     char filename[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
     lxw_error err;
 
@@ -440,7 +449,7 @@ _write_drawing_files(lxw_packager *self)
             lxw_snprintf(filename, LXW_FILENAME_LENGTH,
                          "xl/drawings/drawing%d.xml", index++);
 
-            drawing->file = lxw_tmpfile(self->tmpdir);
+            drawing->file = lxw_memstream(&buf, NULL, self->tmpdir);
             if (!drawing->file)
                 return LXW_ERROR_CREATING_TMPFILE;
 
@@ -448,6 +457,7 @@ _write_drawing_files(lxw_packager *self)
 
             err = _add_file_to_zip(self, drawing->file, filename);
             fclose(drawing->file);
+            free(buf);
             RETURN_ON_ERROR(err);
         }
     }
@@ -496,6 +506,7 @@ _write_table_files(lxw_packager *self)
     lxw_error err;
 
     char filename[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
 
     STAILQ_FOREACH(sheet, workbook->sheets, list_pointers) {
@@ -518,7 +529,7 @@ _write_table_files(lxw_packager *self)
                 RETURN_ON_ERROR(err);
             }
 
-            table->file = lxw_tmpfile(self->tmpdir);
+            table->file = lxw_memstream(&buf, NULL, self->tmpdir);
             if (!table->file) {
                 lxw_table_free(table);
                 return LXW_ERROR_CREATING_TMPFILE;
@@ -530,6 +541,7 @@ _write_table_files(lxw_packager *self)
 
             err = _add_file_to_zip(self, table->file, filename);
             fclose(table->file);
+            free(buf);
             lxw_table_free(table);
             RETURN_ON_ERROR(err);
         }
@@ -572,6 +584,7 @@ _write_vml_files(lxw_packager *self)
     lxw_worksheet *worksheet;
     lxw_vml *vml;
     char filename[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
     lxw_error err;
 
@@ -593,7 +606,7 @@ _write_vml_files(lxw_packager *self)
             lxw_snprintf(filename, LXW_FILENAME_LENGTH,
                          "xl/drawings/vmlDrawing%d.vml", index++);
 
-            vml->file = lxw_tmpfile(self->tmpdir);
+            vml->file = lxw_memstream(&buf, NULL, self->tmpdir);
             if (!vml->file) {
                 lxw_vml_free(vml);
                 return LXW_ERROR_CREATING_TMPFILE;
@@ -609,6 +622,7 @@ _write_vml_files(lxw_packager *self)
             }
             else {
                 fclose(vml->file);
+                free(buf);
                 lxw_vml_free(vml);
                 return LXW_ERROR_MEMORY_MALLOC_FAILED;
             }
@@ -618,6 +632,7 @@ _write_vml_files(lxw_packager *self)
             err = _add_file_to_zip(self, vml->file, filename);
 
             fclose(vml->file);
+            free(buf);
             lxw_vml_free(vml);
 
             RETURN_ON_ERROR(err);
@@ -635,7 +650,7 @@ _write_vml_files(lxw_packager *self)
             lxw_snprintf(filename, LXW_FILENAME_LENGTH,
                          "xl/drawings/vmlDrawing%d.vml", index++);
 
-            vml->file = lxw_tmpfile(self->tmpdir);
+            vml->file = lxw_memstream(&buf, NULL, self->tmpdir);
             if (!vml->file) {
                 lxw_vml_free(vml);
                 return LXW_ERROR_CREATING_TMPFILE;
@@ -649,6 +664,7 @@ _write_vml_files(lxw_packager *self)
             }
             else {
                 fclose(vml->file);
+                free(buf);
                 lxw_vml_free(vml);
                 return LXW_ERROR_MEMORY_MALLOC_FAILED;
             }
@@ -658,6 +674,7 @@ _write_vml_files(lxw_packager *self)
             err = _add_file_to_zip(self, vml->file, filename);
 
             fclose(vml->file);
+            free(buf);
             lxw_vml_free(vml);
 
             RETURN_ON_ERROR(err);
@@ -678,6 +695,7 @@ _write_comment_files(lxw_packager *self)
     lxw_worksheet *worksheet;
     lxw_comment *comment;
     char filename[LXW_FILENAME_LENGTH] = { 0 };
+    char *buf = NULL;
     uint32_t index = 1;
     lxw_error err;
 
@@ -697,7 +715,7 @@ _write_comment_files(lxw_packager *self)
         lxw_snprintf(filename, LXW_FILENAME_LENGTH,
                      "xl/comments%d.xml", index++);
 
-        comment->file = lxw_tmpfile(self->tmpdir);
+        comment->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!comment->file) {
             lxw_comment_free(comment);
             return LXW_ERROR_CREATING_TMPFILE;
@@ -711,6 +729,7 @@ _write_comment_files(lxw_packager *self)
         err = _add_file_to_zip(self, comment->file, filename);
 
         fclose(comment->file);
+        free(buf);
         lxw_comment_free(comment);
 
         RETURN_ON_ERROR(err);
@@ -726,13 +745,14 @@ STATIC lxw_error
 _write_shared_strings_file(lxw_packager *self)
 {
     lxw_sst *sst = self->workbook->sst;
+    char *buf = NULL;
     lxw_error err;
 
     /* Skip the sharedStrings file if there are no shared strings. */
     if (!sst->string_count)
         return LXW_NO_ERROR;
 
-    sst->file = lxw_tmpfile(self->tmpdir);
+    sst->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!sst->file)
         return LXW_ERROR_CREATING_TMPFILE;
 
@@ -740,6 +760,7 @@ _write_shared_strings_file(lxw_packager *self)
 
     err = _add_file_to_zip(self, sst->file, "xl/sharedStrings.xml");
     fclose(sst->file);
+    free(buf);
     RETURN_ON_ERROR(err);
 
     return LXW_NO_ERROR;
@@ -757,6 +778,7 @@ _write_app_file(lxw_packager *self)
     lxw_chartsheet *chartsheet;
     lxw_defined_name *defined_name;
     lxw_app *app;
+    char *buf = NULL;
     uint32_t named_range_count = 0;
     char *autofilter;
     char *has_range;
@@ -769,7 +791,7 @@ _write_app_file(lxw_packager *self)
         goto mem_error;
     }
 
-    app->file = lxw_tmpfile(self->tmpdir);
+    app->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!app->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -830,6 +852,7 @@ _write_app_file(lxw_packager *self)
     err = _add_file_to_zip(self, app->file, "docProps/app.xml");
 
     fclose(app->file);
+    free(buf);
 
 mem_error:
     lxw_app_free(app);
@@ -845,13 +868,14 @@ _write_core_file(lxw_packager *self)
 {
     lxw_error err = LXW_NO_ERROR;
     lxw_core *core = lxw_core_new();
+    char *buf = NULL;
 
     if (!core) {
         err = LXW_ERROR_MEMORY_MALLOC_FAILED;
         goto mem_error;
     }
 
-    core->file = lxw_tmpfile(self->tmpdir);
+    core->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!core->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -864,6 +888,7 @@ _write_core_file(lxw_packager *self)
     err = _add_file_to_zip(self, core->file, "docProps/core.xml");
 
     fclose(core->file);
+    free(buf);
 
 mem_error:
     lxw_core_free(core);
@@ -879,6 +904,7 @@ _write_metadata_file(lxw_packager *self)
 {
     lxw_error err = LXW_NO_ERROR;
     lxw_metadata *metadata;
+    char *buf = NULL;
 
     if (!self->workbook->has_metadata)
         return LXW_NO_ERROR;
@@ -890,7 +916,7 @@ _write_metadata_file(lxw_packager *self)
         goto mem_error;
     }
 
-    metadata->file = lxw_tmpfile(self->tmpdir);
+    metadata->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!metadata->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -901,6 +927,7 @@ _write_metadata_file(lxw_packager *self)
     err = _add_file_to_zip(self, metadata->file, "xl/metadata.xml");
 
     fclose(metadata->file);
+    free(buf);
 
 mem_error:
     lxw_metadata_free(metadata);
@@ -915,6 +942,7 @@ STATIC lxw_error
 _write_custom_file(lxw_packager *self)
 {
     lxw_custom *custom;
+    char *buf = NULL;
     lxw_error err = LXW_NO_ERROR;
 
     if (STAILQ_EMPTY(self->workbook->custom_properties))
@@ -926,7 +954,7 @@ _write_custom_file(lxw_packager *self)
         goto mem_error;
     }
 
-    custom->file = lxw_tmpfile(self->tmpdir);
+    custom->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!custom->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -939,6 +967,7 @@ _write_custom_file(lxw_packager *self)
     err = _add_file_to_zip(self, custom->file, "docProps/custom.xml");
 
     fclose(custom->file);
+    free(buf);
 
 mem_error:
     lxw_custom_free(custom);
@@ -953,13 +982,14 @@ _write_theme_file(lxw_packager *self)
 {
     lxw_error err = LXW_NO_ERROR;
     lxw_theme *theme = lxw_theme_new();
+    char *buf = NULL;
 
     if (!theme) {
         err = LXW_ERROR_MEMORY_MALLOC_FAILED;
         goto mem_error;
     }
 
-    theme->file = lxw_tmpfile(self->tmpdir);
+    theme->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!theme->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -970,6 +1000,7 @@ _write_theme_file(lxw_packager *self)
     err = _add_file_to_zip(self, theme->file, "xl/theme/theme1.xml");
 
     fclose(theme->file);
+    free(buf);
 
 mem_error:
     lxw_theme_free(theme);
@@ -984,6 +1015,7 @@ STATIC lxw_error
 _write_styles_file(lxw_packager *self)
 {
     lxw_styles *styles = lxw_styles_new();
+    char *buf = NULL;
     lxw_hash_element *hash_element;
     lxw_error err = LXW_NO_ERROR;
 
@@ -1030,7 +1062,7 @@ _write_styles_file(lxw_packager *self)
     styles->dxf_count = self->workbook->used_dxf_formats->unique_count;
     styles->has_comments = self->workbook->has_comments;
 
-    styles->file = lxw_tmpfile(self->tmpdir);
+    styles->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!styles->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -1041,6 +1073,7 @@ _write_styles_file(lxw_packager *self)
     err = _add_file_to_zip(self, styles->file, "xl/styles.xml");
 
     fclose(styles->file);
+    free(buf);
 
 mem_error:
     lxw_styles_free(styles);
@@ -1055,6 +1088,7 @@ STATIC lxw_error
 _write_content_types_file(lxw_packager *self)
 {
     lxw_content_types *content_types = lxw_content_types_new();
+    char *buf = NULL;
     lxw_workbook *workbook = self->workbook;
     lxw_sheet *sheet;
     char filename[LXW_MAX_ATTRIBUTE_LENGTH] = { 0 };
@@ -1071,7 +1105,7 @@ _write_content_types_file(lxw_packager *self)
         goto mem_error;
     }
 
-    content_types->file = lxw_tmpfile(self->tmpdir);
+    content_types->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!content_types->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -1154,6 +1188,7 @@ _write_content_types_file(lxw_packager *self)
     err = _add_file_to_zip(self, content_types->file, "[Content_Types].xml");
 
     fclose(content_types->file);
+    free(buf);
 
 mem_error:
     lxw_content_types_free(content_types);
@@ -1168,6 +1203,7 @@ STATIC lxw_error
 _write_workbook_rels_file(lxw_packager *self)
 {
     lxw_relationships *rels = lxw_relationships_new();
+    char *buf = NULL;
     lxw_workbook *workbook = self->workbook;
     lxw_sheet *sheet;
     char sheetname[LXW_FILENAME_LENGTH] = { 0 };
@@ -1180,7 +1216,7 @@ _write_workbook_rels_file(lxw_packager *self)
         goto mem_error;
     }
 
-    rels->file = lxw_tmpfile(self->tmpdir);
+    rels->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!rels->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -1220,6 +1256,7 @@ _write_workbook_rels_file(lxw_packager *self)
     err = _add_file_to_zip(self, rels->file, "xl/_rels/workbook.xml.rels");
 
     fclose(rels->file);
+    free(buf);
 
 mem_error:
     lxw_free_relationships(rels);
@@ -1235,6 +1272,7 @@ STATIC lxw_error
 _write_worksheet_rels_file(lxw_packager *self)
 {
     lxw_relationships *rels;
+    char *buf = NULL;
     lxw_rel_tuple *rel;
     lxw_workbook *workbook = self->workbook;
     lxw_sheet *sheet;
@@ -1262,7 +1300,7 @@ _write_worksheet_rels_file(lxw_packager *self)
 
         rels = lxw_relationships_new();
 
-        rels->file = lxw_tmpfile(self->tmpdir);
+        rels->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!rels->file) {
             lxw_free_relationships(rels);
             return LXW_ERROR_CREATING_TMPFILE;
@@ -1311,6 +1349,7 @@ _write_worksheet_rels_file(lxw_packager *self)
         err = _add_file_to_zip(self, rels->file, sheetname);
 
         fclose(rels->file);
+        free(buf);
         lxw_free_relationships(rels);
 
         RETURN_ON_ERROR(err);
@@ -1327,6 +1366,7 @@ STATIC lxw_error
 _write_chartsheet_rels_file(lxw_packager *self)
 {
     lxw_relationships *rels;
+    char *buf = NULL;
     lxw_rel_tuple *rel;
     lxw_workbook *workbook = self->workbook;
     lxw_sheet *sheet;
@@ -1348,7 +1388,7 @@ _write_chartsheet_rels_file(lxw_packager *self)
 
         rels = lxw_relationships_new();
 
-        rels->file = lxw_tmpfile(self->tmpdir);
+        rels->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!rels->file) {
             lxw_free_relationships(rels);
             return LXW_ERROR_CREATING_TMPFILE;
@@ -1372,6 +1412,7 @@ _write_chartsheet_rels_file(lxw_packager *self)
         err = _add_file_to_zip(self, rels->file, sheetname);
 
         fclose(rels->file);
+        free(buf);
         lxw_free_relationships(rels);
 
         RETURN_ON_ERROR(err);
@@ -1388,6 +1429,7 @@ STATIC lxw_error
 _write_drawing_rels_file(lxw_packager *self)
 {
     lxw_relationships *rels;
+    char *buf = NULL;
     lxw_rel_tuple *rel;
     lxw_workbook *workbook = self->workbook;
     lxw_sheet *sheet;
@@ -1407,7 +1449,7 @@ _write_drawing_rels_file(lxw_packager *self)
 
         rels = lxw_relationships_new();
 
-        rels->file = lxw_tmpfile(self->tmpdir);
+        rels->file = lxw_memstream(&buf, NULL, self->tmpdir);
         if (!rels->file) {
             lxw_free_relationships(rels);
             return LXW_ERROR_CREATING_TMPFILE;
@@ -1427,6 +1469,7 @@ _write_drawing_rels_file(lxw_packager *self)
         err = _add_file_to_zip(self, rels->file, sheetname);
 
         fclose(rels->file);
+        free(buf);
         lxw_free_relationships(rels);
 
         RETURN_ON_ERROR(err);
@@ -1444,13 +1487,14 @@ _write_vml_drawing_rels_file(lxw_packager *self, lxw_worksheet *worksheet,
                              uint32_t index)
 {
     lxw_relationships *rels;
+    char *buf = NULL;
     lxw_rel_tuple *rel;
     char sheetname[LXW_FILENAME_LENGTH] = { 0 };
     lxw_error err = LXW_NO_ERROR;
 
     rels = lxw_relationships_new();
 
-    rels->file = lxw_tmpfile(self->tmpdir);
+    rels->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!rels->file) {
         lxw_free_relationships(rels);
         return LXW_ERROR_CREATING_TMPFILE;
@@ -1470,6 +1514,7 @@ _write_vml_drawing_rels_file(lxw_packager *self, lxw_worksheet *worksheet,
     err = _add_file_to_zip(self, rels->file, sheetname);
 
     fclose(rels->file);
+    free(buf);
     lxw_free_relationships(rels);
 
     return err;
@@ -1482,6 +1527,7 @@ STATIC lxw_error
 _write_root_rels_file(lxw_packager *self)
 {
     lxw_relationships *rels = lxw_relationships_new();
+    char *buf = NULL;
     lxw_error err = LXW_NO_ERROR;
 
     if (!rels) {
@@ -1489,7 +1535,7 @@ _write_root_rels_file(lxw_packager *self)
         goto mem_error;
     }
 
-    rels->file = lxw_tmpfile(self->tmpdir);
+    rels->file = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!rels->file) {
         err = LXW_ERROR_CREATING_TMPFILE;
         goto mem_error;
@@ -1514,6 +1560,7 @@ _write_root_rels_file(lxw_packager *self)
     err = _add_file_to_zip(self, rels->file, "_rels/.rels");
 
     fclose(rels->file);
+    free(buf);
 
 mem_error:
     lxw_free_relationships(rels);
@@ -1555,7 +1602,7 @@ _add_file_to_zip(lxw_packager *self, FILE * file, const char *filename)
     while (size_read) {
 
         if (size_read < self->buffer_size) {
-            if (feof(file) == 0) {
+            if (ferror(file)) {
                 LXW_ERROR("Error reading member file data");
                 RETURN_ON_ZIP_ERROR(error, LXW_ERROR_ZIP_FILE_ADD);
             }

--- a/src/utility.c
+++ b/src/utility.c
@@ -586,7 +586,7 @@ lxw_tmpfile(char *tmpdir)
  * Return a memory-backed file if supported, otherwise a temporary one
  */
 FILE *
-lxw_memstream(char **buf, size_t *size, char *tmpdir)
+lxw_get_filehandle(char **buf, size_t *size, char *tmpdir)
 {
     static size_t s;
     if (!size)

--- a/src/utility.c
+++ b/src/utility.c
@@ -7,6 +7,10 @@
  *
  */
 
+#ifdef USE_FMEMOPEN
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
@@ -575,6 +579,25 @@ lxw_tmpfile(char *tmpdir)
 #else
     (void) tmpdir;
     return tmpfile();
+#endif
+}
+
+/**
+ * Return a memory-backed file if supported, otherwise a temporary one
+ */
+FILE *
+lxw_memstream(char **buf, size_t *size, char *tmpdir)
+{
+    static size_t s;
+    if (!size)
+        size = &s;
+    *buf = NULL;
+    *size = 0;
+#ifdef USE_FMEMOPEN
+    (void) tmpdir;
+    return open_memstream(buf, size);
+#else
+    return lxw_tmpfile(tmpdir);
 #endif
 }
 

--- a/src/workbook.c
+++ b/src/workbook.c
@@ -1880,6 +1880,8 @@ workbook_new_opt(const char *filename, lxw_workbook_options *options)
         workbook->options.constant_memory = options->constant_memory;
         workbook->options.tmpdir = lxw_strdup(options->tmpdir);
         workbook->options.use_zip64 = options->use_zip64;
+        workbook->options.output_buffer = options->output_buffer;
+        workbook->options.output_buffer_size = options->output_buffer_size;
     }
 
     workbook->max_url_length = 2079;
@@ -2191,6 +2193,11 @@ workbook_close(lxw_workbook *self)
 
     /* Assemble all the sub-files in the xlsx package. */
     error = lxw_create_package(packager);
+
+    if (!self->filename) {
+        *self->options.output_buffer = packager->output_buffer;
+        *self->options.output_buffer_size = packager->output_buffer_size;
+    }
 
     /* Error and non-error conditions fall through to the cleanup code. */
     if (error == LXW_ERROR_CREATING_TMPFILE) {

--- a/src/worksheet.c
+++ b/src/worksheet.c
@@ -196,8 +196,8 @@ lxw_worksheet_new(lxw_worksheet_init_data *init_data)
         FILE *tmpfile;
 
         worksheet->optimize_buffer = NULL;
-        tmpfile = lxw_memstream(&worksheet->optimize_buffer,
-                                NULL, init_data->tmpdir);
+        tmpfile = lxw_get_filehandle(&worksheet->optimize_buffer,
+                                     NULL, init_data->tmpdir);
         if (!tmpfile) {
             LXW_ERROR("Error creating tmpfile() for worksheet in "
                       "'constant_memory' mode.");
@@ -8418,7 +8418,7 @@ worksheet_write_rich_string(lxw_worksheet *self,
     lxw_format *default_format = NULL;
     lxw_rich_string_tuple *rich_string_tuple = NULL;
     FILE *tmpfile;
-    char *buf = NULL;
+    char *buffer = NULL;
 
     err = _check_dimensions(self, row_num, col_num, LXW_FALSE, LXW_FALSE);
     if (err)
@@ -8443,7 +8443,7 @@ worksheet_write_rich_string(lxw_worksheet *self,
         return err;
 
     /* Create a tmp file for the styles object. */
-    tmpfile = lxw_memstream(&buf, NULL, self->tmpdir);
+    tmpfile = lxw_get_filehandle(&buffer, NULL, self->tmpdir);
     if (!tmpfile)
         return LXW_ERROR_CREATING_TMPFILE;
 
@@ -8491,14 +8491,14 @@ worksheet_write_rich_string(lxw_worksheet *self,
     rewind(tmpfile);
     if (fread(rich_string, file_size, 1, tmpfile) < 1) {
         fclose(tmpfile);
-        free(buf);
+        free(buffer);
         free(rich_string);
         return LXW_ERROR_READING_TMPFILE;
     }
 
     /* Close the temp file. */
     fclose(tmpfile);
-    free(buf);
+    free(buffer);
 
     if (lxw_utf8_strlen(rich_string) > LXW_STR_MAX) {
         free(rich_string);
@@ -8538,7 +8538,7 @@ mem_error:
     lxw_styles_free(styles);
     lxw_format_free(default_format);
     fclose(tmpfile);
-    free(buf);
+    free(buffer);
 
     return LXW_ERROR_MEMORY_MALLOC_FAILED;
 }

--- a/src/worksheet.c
+++ b/src/worksheet.c
@@ -195,7 +195,9 @@ lxw_worksheet_new(lxw_worksheet_init_data *init_data)
     if (init_data && init_data->optimize) {
         FILE *tmpfile;
 
-        tmpfile = lxw_tmpfile(init_data->tmpdir);
+        worksheet->optimize_buffer = NULL;
+        tmpfile = lxw_memstream(&worksheet->optimize_buffer,
+                                NULL, init_data->tmpdir);
         if (!tmpfile) {
             LXW_ERROR("Error creating tmpfile() for worksheet in "
                       "'constant_memory' mode.");
@@ -2536,6 +2538,7 @@ _worksheet_write_optimized_sheet_data(lxw_worksheet *self)
         }
 
         fclose(self->optimize_tmpfile);
+        free(self->optimize_buffer);
 
         lxw_xml_end_tag(self->file, "sheetData");
     }
@@ -8415,6 +8418,7 @@ worksheet_write_rich_string(lxw_worksheet *self,
     lxw_format *default_format = NULL;
     lxw_rich_string_tuple *rich_string_tuple = NULL;
     FILE *tmpfile;
+    char *buf = NULL;
 
     err = _check_dimensions(self, row_num, col_num, LXW_FALSE, LXW_FALSE);
     if (err)
@@ -8439,7 +8443,7 @@ worksheet_write_rich_string(lxw_worksheet *self,
         return err;
 
     /* Create a tmp file for the styles object. */
-    tmpfile = lxw_tmpfile(self->tmpdir);
+    tmpfile = lxw_memstream(&buf, NULL, self->tmpdir);
     if (!tmpfile)
         return LXW_ERROR_CREATING_TMPFILE;
 
@@ -8487,12 +8491,14 @@ worksheet_write_rich_string(lxw_worksheet *self,
     rewind(tmpfile);
     if (fread(rich_string, file_size, 1, tmpfile) < 1) {
         fclose(tmpfile);
+        free(buf);
         free(rich_string);
         return LXW_ERROR_READING_TMPFILE;
     }
 
     /* Close the temp file. */
     fclose(tmpfile);
+    free(buf);
 
     if (lxw_utf8_strlen(rich_string) > LXW_STR_MAX) {
         free(rich_string);
@@ -8532,6 +8538,7 @@ mem_error:
     lxw_styles_free(styles);
     lxw_format_free(default_format);
     fclose(tmpfile);
+    free(buf);
 
     return LXW_ERROR_MEMORY_MALLOC_FAILED;
 }

--- a/test/functional/src/test_optimize01.c
+++ b/test/functional/src/test_optimize01.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize01.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize02.c
+++ b/test/functional/src/test_optimize02.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize02.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize04.c
+++ b/test/functional/src/test_optimize04.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize04.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize05.c
+++ b/test/functional/src/test_optimize05.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize05.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize06.c
+++ b/test/functional/src/test_optimize06.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize06.xlsx", &options);
 

--- a/test/functional/src/test_optimize08.c
+++ b/test/functional/src/test_optimize08.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize08.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize21.c
+++ b/test/functional/src/test_optimize21.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize21.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize22.c
+++ b/test/functional/src/test_optimize22.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize22.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize23.c
+++ b/test/functional/src/test_optimize23.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize23.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize24.c
+++ b/test/functional/src/test_optimize24.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize24.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize25.c
+++ b/test/functional/src/test_optimize25.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize25.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_optimize26.c
+++ b/test/functional/src/test_optimize26.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, NULL, LXW_FALSE, NULL, NULL};
 
     /* Use deprecated constructor for testing. */
     lxw_workbook  *workbook  = workbook_new_opt("test_optimize26.xlsx", &options);

--- a/test/functional/src/test_output_buffer01.c
+++ b/test/functional/src/test_output_buffer01.c
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Test cases for libxlsxwriter.
+ *
+ * Simple test case to test data writing.
+ *
+ * Copyright 2014-2022, John McNamara, jmcnamara@cpan.org
+ *
+ */
+
+#include "xlsxwriter.h"
+
+int main() {
+    char *output_buffer;
+    size_t output_buffer_size;
+    lxw_workbook_options options = {LXW_FALSE,
+                                    ".",
+                                    LXW_FALSE,
+                                    &output_buffer,
+                                    &output_buffer_size};
+
+    lxw_workbook  *workbook  = workbook_new_opt(NULL, &options);
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
+
+    worksheet_write_string(worksheet, 0, 0, "Hello", NULL);
+    worksheet_write_number(worksheet, 1, 0, 123,     NULL);
+
+    int error = workbook_close(workbook);
+    if (error)
+        return error;
+
+    FILE *file = fopen("test_output_buffer01.xlsx", "wb");
+    fwrite(output_buffer, output_buffer_size, 1, file);
+    fclose(file);
+    free(output_buffer);
+
+    return 0;
+}

--- a/test/functional/src/test_tmpdir01.c
+++ b/test/functional/src/test_tmpdir01.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_FALSE, ".", LXW_FALSE};
+    lxw_workbook_options options = {LXW_FALSE, ".", LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_tmpdir01.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/src/test_tmpdir02.c
+++ b/test/functional/src/test_tmpdir02.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    lxw_workbook_options options = {LXW_TRUE, ".", LXW_FALSE};
+    lxw_workbook_options options = {LXW_TRUE, ".", LXW_FALSE, NULL, NULL};
 
     lxw_workbook  *workbook  = workbook_new_opt("test_tmpdir02.xlsx", &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/test/functional/test_output_buffer.py
+++ b/test/functional/test_output_buffer.py
@@ -1,0 +1,17 @@
+###############################################################################
+#
+# Tests for libxlsxwriter.
+#
+# Copyright 2014-2022, John McNamara, jmcnamara@cpan.org
+#
+
+import base_test_class
+
+class TestCompareXLSXFiles(base_test_class.XLSXBaseTest):
+    """
+    Test file created with libxlsxwriter against a file created by Excel.
+
+    """
+
+    def test_output_buffer01(self):
+        self.run_exe_test('test_output_buffer01', 'simple01.xlsx')


### PR DESCRIPTION
This extends the realm of `USE_FMEMOPEN` to all temporary files, which is accomplished by using `open_memstream`. It also adds two new workbook options, `output_buffer` and `output_buffer_size`, to allow outputting to a buffer when filename is `NULL`. This allows the library to be used without writing to the filesystem.