### PR TITLE
Improve buffer support

### DIFF
--- a/include/xlsxwriter/worksheet.h
+++ b/include/xlsxwriter/worksheet.h
@@ -1793,7 +1793,7 @@ typedef struct lxw_object_properties {
     FILE *stream;
     uint8_t image_type;
     uint8_t is_image_buffer;
-    unsigned char *image_buffer;
+    char *image_buffer;
     size_t image_buffer_size;
     double width;
     double height;
@@ -2109,6 +2109,7 @@ typedef struct lxw_worksheet {
     FILE *file;
     FILE *optimize_tmpfile;
     char *optimize_buffer;
+    size_t optimize_buffer_size;
     struct lxw_table_rows *table;
     struct lxw_table_rows *hyperlinks;
     struct lxw_table_rows *comments;


### PR DESCRIPTION
macOS does not like rewinding and reading from a memstream (it messes up the buffer) which is fair enough - per spec, `open_memstream()` returns a write-only stream. This PR ensures the buffer is read from directly to avoid this.