### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "libxlsxwriter",
+    products: [
+        .library(
+            name: "libxlsxwriter",
+            targets: ["libxlsxwriter"]),
+    ],
+    targets: [
+        .target(
+            name: "libxlsxwriter",
+            path: ".",
+            exclude: [
+                "src/Makefile",
+            ],
+            sources: [
+                "include",
+                "src",
+                "third_party/minizip/zip.c",
+                "third_party/minizip/ioapi.c",
+                "third_party/tmpfileplus/tmpfileplus.c",
+                "third_party/md5/md5.c"
+            ],
+            publicHeadersPath: "include",
+            linkerSettings: [
+                .linkedLibrary("z")
+            ]),
+        .testTarget(
+            name: "libxlsxwritertests",
+            dependencies: ["libxlsxwriter"],
+            path: ".",
+            sources: ["test/swift"],
+            linkerSettings: [
+                .linkedLibrary("z")
+            ]
+        )
+    ]
+)

--- a/test/swift/test.swift
+++ b/test/swift/test.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import libxlsxwriter
+
+final class LibXlsxWriterTests: XCTestCase {
+    func testExample() throws {
+        let documentDirectory = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor:nil, create:false)
+        let fileURL = documentDirectory.appendingPathComponent("hello_world.xlsx")
+
+        let workbook = workbook_new((fileURL.absoluteString.dropFirst(6) as NSString).fileSystemRepresentation)
+        let worksheet = workbook_add_worksheet(workbook, nil)
+        worksheet_write_string(worksheet, 0, 0, "Hello", nil)
+        worksheet_write_number(worksheet, 1, 0, 123, nil)
+        workbook_close(workbook)
+
+        print(fileURL)
+    }
+}


### PR DESCRIPTION
Fix #390

The test verifies that the library can be used from a Swift context. This was helpful to solve missing symbols as I chose which files I had to include. In the end, looking at the `.podspec` was very helpful. 