### PR TITLE
Remove SonarCloud cache and threads configuration and rely on default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,9 +210,7 @@ endif
         -Dsonar.cfamily.build-wrapper-output=build \
         -Dsonar.working.directory=build/scannerwork \
         -Dsonar.host.url=https://sonarcloud.io \
-        -Dsonar.cfamily.threads=4 \
-        -Dsonar.coverageReportPaths=build/coverage.xml \
-        -Dsonar.cfamily.cache.enabled=false
+        -Dsonar.coverageReportPaths=build/coverage.xml
 
 sonarcloud_no_gcov:
 ifndef SONAR_TOKEN
@@ -230,9 +228,7 @@ endif
         -Dsonar.sourceEncoding=UTF-8 \
         -Dsonar.cfamily.build-wrapper-output=build \
         -Dsonar.working.directory=build/scannerwork \
-        -Dsonar.host.url=https://sonarcloud.io \
-        -Dsonar.cfamily.threads=4 \
-        -Dsonar.cfamily.cache.enabled=false
+        -Dsonar.host.url=https://sonarcloud.io
 
 
 # Run a scan-build static analysis.


### PR DESCRIPTION
No need to configure the cache and threads anymore, SonarCloud now has automatic analysis caching and threads configuration. See: https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache

