### PR TITLE
Compatibility with Visual Studio and MS C compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,9 @@ cmake
 !cmake/FindMINIZIP.cmake
 !cmake/FindPackage.cmake
 !cmake/i686-toolchain.cmake
+CMakeSettings.json
 
+.vs
 .vscode
 
 zig-cache/

--- a/include/xlsxwriter/worksheet.h
+++ b/include/xlsxwriter/worksheet.h
@@ -1983,17 +1983,17 @@ typedef struct lxw_header_footer_options {
     /** The left header image filename, with path if required. This should
      * have a corresponding `&G/&[Picture]` placeholder in the `&L` section of
      * the header/footer string. See `worksheet_set_header_opt()`. */
-    char *image_left;
+    const char *image_left;
 
     /** The center header image filename, with path if required. This should
      * have a corresponding `&G/&[Picture]` placeholder in the `&C` section of
      * the header/footer string. See `worksheet_set_header_opt()`. */
-    char *image_center;
+    const char *image_center;
 
     /** The right header image filename, with path if required. This should
      * have a corresponding `&G/&[Picture]` placeholder in the `&R` section of
      * the header/footer string. See `worksheet_set_header_opt()`. */
-    char *image_right;
+    const char *image_right;
 
 } lxw_header_footer_options;
 

--- a/src/worksheet.c
+++ b/src/worksheet.c
@@ -4743,13 +4743,13 @@ lxw_worksheet_write_single_row(lxw_worksheet *self)
 
 /* Process a header/footer image and store it in the correct slot. */
 lxw_error
-_worksheet_set_header_footer_image(lxw_worksheet *self, char *filename,
+_worksheet_set_header_footer_image(lxw_worksheet *self, const char *filename,
                                    uint8_t image_position)
 {
     FILE *image_stream;
     const char *description;
     lxw_object_properties *object_props;
-    char *image_strings[] = { "LH", "CH", "RH", "LF", "CF", "RF" };
+    const char *image_strings[] = { "LH", "CH", "RH", "LF", "CF", "RF" };
 
     /* Not all slots will have image files. */
     if (!filename)


### PR DESCRIPTION
PR for issue #413 

Fix unit tests:
- `ctest.h`: make unit test registration and iteration work: use linker segments `.ctest$a`, `.ctest$b`, `.ctest$c`

Additional fixes for building with VS:
- fix build error in VS: use `const char*` in struct `lxw_header_footer_options`, `_worksheet_set_header_footer_image`
- extend `.gitignore` to ignore special local VS directories/files
