### PR TITLE
From zlib: Reject overflows of zip header fields in minizip.

### DIFF
--- a/third_party/minizip/zip.c
+++ b/third_party/minizip/zip.c
@@ -1043,6 +1043,17 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
       return ZIP_PARAMERROR;
 #endif
 
+    // The filename and comment length must fit in 16 bits.
+    if ((filename!=NULL) && (strlen(filename)>0xffff))
+        return ZIP_PARAMERROR;
+    if ((comment!=NULL) && (strlen(comment)>0xffff))
+        return ZIP_PARAMERROR;
+    // The extra field length must fit in 16 bits. If the member also requires
+    // a Zip64 extra block, that will also need to fit within that 16-bit
+    // length, but that will be checked for later.
+    if ((size_extrafield_local>0xffff) || (size_extrafield_global>0xffff))
+        return ZIP_PARAMERROR;
+
     zi = (zip64_internal*)file;
 
     if (zi->in_opened_file_inzip == 1)


### PR DESCRIPTION
With the `minizip` code in the codebase updated by #420, it's fairly straightforward to cherry-pick a fixup for CVE-2023-45853.

If-and-when a release of `zlib` v1.3.1 (that contains `minizip` in the `contrib` directory) appears, it could be worthwhile to update to that; since that hasn't appeared yet I think it may make sense to apply this here directly.