### PR TITLE
Add FreeBSD CI via Cirrus-CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+FreeBSD_task:
+  freebsd_instance:
+    image_family: freebsd-14-0
+  setup_script:
+    pkg install -y gmake devel/py-pytest
+  build_script:
+    gmake
+  test_script:
+    gmake test


### PR DESCRIPTION
Apologies for not opening an issue first -- this is not a bug report or really a new feature, and to me it seems for this change an open issue wouldn't add much value. But I'm happy to do so, if that's important for your workflow / tracking.

This change adds FreeBSD build + test CI via [Cirrus-CI](https://cirrus-ci.org). For a sample run see https://cirrus-ci.com/build/5293314581200896

Enabling it requires adding the Cirrus-CI application, documented at https://cirrus-ci.org/guide/quick-start/.