### PR TITLE
zig-build: lazyPath fixes

### DIFF
--- a/.github/workflows/zig_build.yml
+++ b/.github/workflows/zig_build.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.13.0
 
       - name: Build Summary
         run: zig build -DBUILD_TESTS -DBUILD_EXAMPLES -DUSE_SYSTEM_MINIZIP --summary all -freference-trace

--- a/.github/workflows/zig_build.yml
+++ b/.github/workflows/zig_build.yml
@@ -14,9 +14,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: 0.13.0
+      - uses: mlugg/setup-zig@v1 # default latest-release version
 
       - name: Build Summary
         run: zig build -DBUILD_TESTS -DBUILD_EXAMPLES -DUSE_SYSTEM_MINIZIP --summary all -freference-trace

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ cmake
 
 .vscode
 
-zig-cache/
+*zig-cache/
 zig-out/

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,10 @@
 .{
     .name = "libxlsxwriter",
-    .version = "1.1.7",
+    .version = "1.1.9",
     .dependencies = .{
         .zlib = .{
-            .url = "git+https://github.com/madler/zlib#0f51fb4933fc9ce18199cb2554dacea8033e7fd3",
-            .hash = "12204f12291d6eeb1e05f19d8ab0c7f46c9073fae4c3568dcae7aade149db0b45047",
-            .lazy = true,
+            .url = "git+https://github.com/madler/zlib#v1.3.1",
+            .hash = "1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb",
         },
     },
     .paths = .{
@@ -13,6 +12,9 @@
         "build.zig.zon",
         "Readme.md",
         "License.txt",
+        "src",
+        "include",
+        "third_party",
     },
 }
 //syntax tip: zig - anon struct (json-like)


### PR DESCRIPTION
Minor fix: lazyPath

`b.path("path")` - get src/subpath contents - not allow abspath
old `.{ .path = "path" }` was renamed to `.{ .cwd_relative = "abspath" }` - for external path.

Works on zig version: v0.12.0 (optional change), v0.12.1, v0.13.0 & v0.14.0-dev (currently master);

**Note:** old zig version generate `zig-cache`, but v013.0 and master rename to `.zig-cache`!

Extra update: replacing zlib-master to release-version

```bash
$ zig fetch --save=zlib git+https://github.com/madler/zlib#v1.3.1
info: resolved ref 'v1.3.1' to commit 51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf
warning: overwriting existing dependency named 'zlib'
```
cc: @jmcnamara 