### PR TITLE
#465 change from defineCMacro to addCMacro

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) void {
         else => lib.root_module.strip = true,
     }
     if (tests)
-        lib.defineCMacro("TESTING", null);
+        lib.root_module.addCMacro("TESTING", "");
     lib.addCSourceFiles(.{
         .files = &.{
             "src/vml.c",
@@ -107,7 +107,7 @@ pub fn build(b: *std.Build) void {
             .flags = cflags,
         })
     else
-        lib.defineCMacro("USE_STANDARD_TMPFILE", null);
+        lib.root_module.addCMacro("USE_STANDARD_TMPFILE", "");
 
     lib.addIncludePath(b.path("include"));
     lib.addIncludePath(b.path("third_party"));
@@ -283,7 +283,7 @@ fn buildTest(b: *std.Build, info: BuildInfo) void {
         .optimize = info.lib.root_module.optimize.?,
         .target = info.lib.root_module.resolved_target.?,
     });
-    exe.defineCMacro("TESTING", null);
+    exe.root_module.addCMacro("TESTING", "");
     exe.addCSourceFile(.{
         .file = b.path(info.path),
         .flags = cflags,


### PR DESCRIPTION
Small change to build.zig due to change in the zig build system, in the way it passes C Macros from the Zig build system to the target 

defineCMacro() -> deprecated in favour of -> root_lib.addCMacro()

Recently deprecated & removed from the zig compiler 
https://github.com/ziglang/zig/commit/142471fcc46070326526e3976f0150fe734df0b6

This change has no effect on libxlswriter itself - its a zig issue, no a libxlswriter issue

Tested - built using a patched zig-libxlswriter, and added to my app for end 2 end test to generate spreadsheets. 