### PR TITLE
oss-fuzz: Add unit test build to oss-fuzz build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,8 +354,7 @@ file(GLOB_RECURSE LXW_HEADERS RELATIVE include *.h)
 # If not using the system minizip, add the vendored minizip source files.
 if(NOT USE_SYSTEM_MINIZIP)
     list(
-        APPEND
-        LXW_SOURCES
+        APPEND LXW_SOURCES
         third_party/minizip/ioapi.c
         third_party/minizip/zip.c
     )

--- a/dev/fuzzing/build.sh
+++ b/dev/fuzzing/build.sh
@@ -3,7 +3,7 @@ cd $SRC/libxlsxwriter
 printenv
 
 mkdir -p build
-cmake -S . -B build -DBUILD_FUZZERS=ON && cmake --build build --target install
+cmake -S . -B build -DBUILD_FUZZERS=ON -DBUILD_TESTS=ON && cmake --build build --target install
 
 # Build the corpus using the existing xlsx files in the source
 mkdir -p corpus


### PR DESCRIPTION
OSS-Fuzz has a new Chronos feature that allows fast rebuilding of OSS-Fuzz-integrated projects and checks whether the project code or fuzzers still pass their unit tests after patching. To enable this feature, the unit tests of integrated projects need to be built. Therefore, this PR modifies the build script used by OSS-Fuzz to also build the unit tests for this project. The OSS-Fuzz-side changes for this project's integration can be found here: https://github.com/google/oss-fuzz/pull/14525.

Issue: #497 