### PR TITLE
Add workbook_rename_worksheet() and workbook_remove_worksheet()

### DIFF
--- a/include/xlsxwriter/common.h
+++ b/include/xlsxwriter/common.h
@@ -125,6 +125,9 @@ typedef enum lxw_error {
     /** Worksheet name is already in use. */
     LXW_ERROR_SHEETNAME_ALREADY_USED,
 
+    /** Worksheet name was not found in the workbook. */
+    LXW_ERROR_SHEETNAME_NOT_FOUND,
+
     /** Parameter exceeds Excel's limit of 32 characters. */
     LXW_ERROR_32_STRING_LENGTH_EXCEEDED,
 

--- a/include/xlsxwriter/workbook.h
+++ b/include/xlsxwriter/workbook.h
@@ -928,6 +928,54 @@ lxw_chartsheet *workbook_get_chartsheet_by_name(lxw_workbook *workbook,
                                                 const char *name);
 
 /**
+ * @brief Rename a worksheet.
+ *
+ * @param workbook Pointer to a lxw_workbook instance.
+ * @param old_name The current name of the worksheet to rename.
+ * @param new_name The new name to give the worksheet.
+ *
+ * @return A #lxw_error.
+ *
+ * This function renames an existing worksheet. The lookup of `old_name` and
+ * the check for a duplicate `new_name` are case insensitive, like the other
+ * worksheet name functions.
+ *
+ * @code
+ *     lxw_error err = workbook_rename_worksheet(workbook, "Sheet1", "Data");
+ * @endcode
+ *
+ * Renaming should be carried out before the worksheet is referenced by
+ * formulas, defined names or charts in other worksheets.
+ *
+ */
+lxw_error workbook_rename_worksheet(lxw_workbook *workbook,
+                                    const char *old_name,
+                                    const char *new_name);
+
+/**
+ * @brief Remove a worksheet from the workbook.
+ *
+ * @param workbook Pointer to a lxw_workbook instance.
+ * @param name     The name of the worksheet to remove.
+ *
+ * @return A #lxw_error.
+ *
+ * This function removes a previously added worksheet from the workbook and
+ * frees the associated `lxw_worksheet` object. The lookup of `name` is case
+ * insensitive.
+ *
+ * @code
+ *     lxw_error err = workbook_remove_worksheet(workbook, "Sheet1");
+ * @endcode
+ *
+ * @note The worksheet object must not be used after it is removed. Removing a
+ * worksheet that is referenced by formulas, defined names or charts in other
+ * worksheets will leave those references dangling.
+ *
+ */
+lxw_error workbook_remove_worksheet(lxw_workbook *workbook, const char *name);
+
+/**
  * @brief Validate a worksheet or chartsheet name.
  *
  * @param workbook  Pointer to a lxw_workbook instance.

--- a/src/utility.c
+++ b/src/utility.c
@@ -46,6 +46,7 @@ char *error_strings[LXW_MAX_ERRNO + 1] = {
     "Worksheet name cannot contain invalid characters: '[ ] : * ? / \\'",
     "Worksheet name cannot start or end with an apostrophe.",
     "Worksheet name is already in use.",
+    "Worksheet name was not found.",
     "Parameter exceeds Excel's limit of 32 characters.",
     "Parameter exceeds Excel's limit of 128 characters.",
     "Parameter exceeds Excel's limit of 255 characters.",

--- a/src/workbook.c
+++ b/src/workbook.c
@@ -2724,6 +2724,133 @@ workbook_get_chartsheet_by_name(lxw_workbook *self, const char *name)
 }
 
 /*
+ * Rename a worksheet. The worksheet is looked up by old_name (case
+ * insensitive) and given new_name. The worksheet is temporarily detached
+ * from the RB tree of names so that validating new_name doesn't treat the
+ * worksheet's own name as a collision, which also permits a case-only rename
+ * such as "Sheet1" to "sheet1".
+ */
+lxw_error
+workbook_rename_worksheet(lxw_workbook *self, const char *old_name,
+                          const char *new_name)
+{
+    lxw_worksheet_name lookup;
+    lxw_worksheet_name *node;
+    lxw_error error;
+
+    if (old_name == NULL || new_name == NULL)
+        return LXW_ERROR_NULL_PARAMETER_IGNORED;
+
+    /* Find the worksheet name node by its current name. */
+    lookup.name = old_name;
+    node = RB_FIND(lxw_worksheet_names, self->worksheet_names, &lookup);
+
+    if (!node)
+        return LXW_ERROR_SHEETNAME_NOT_FOUND;
+
+    /* Detach the node before validating new_name. */
+    RB_REMOVE(lxw_worksheet_names, self->worksheet_names, node);
+
+    error = workbook_validate_sheet_name(self, new_name);
+    if (error) {
+        RB_INSERT(lxw_worksheet_names, self->worksheet_names, node);
+        return error;
+    }
+
+    /* The worksheet name and the RB node name share a single allocation (see
+     * workbook_add_worksheet) so free it once and reassign both pointers to
+     * the new allocation to preserve that invariant. */
+    free((void *) node->worksheet->name);
+    free((void *) node->worksheet->quoted_name);
+
+    node->worksheet->name = lxw_strdup(new_name);
+    node->worksheet->quoted_name = lxw_quote_sheetname(new_name);
+    node->name = node->worksheet->name;
+
+    RB_INSERT(lxw_worksheet_names, self->worksheet_names, node);
+
+    return LXW_NO_ERROR;
+}
+
+/*
+ * Remove a worksheet from the workbook. The worksheet is looked up by name
+ * (case insensitive), detached from the name tree and the worksheet and sheet
+ * lists, and freed. The remaining sheets are renumbered so their indexes stay
+ * contiguous and the active/first sheet positions are shifted past the removed
+ * sheet so they keep pointing at the same sheet.
+ */
+lxw_error
+workbook_remove_worksheet(lxw_workbook *self, const char *name)
+{
+    lxw_worksheet_name lookup;
+    lxw_worksheet_name *node;
+    lxw_worksheet *worksheet;
+    lxw_sheet *sheet;
+    uint16_t removed_index;
+    uint16_t new_index;
+
+    if (name == NULL)
+        return LXW_ERROR_NULL_PARAMETER_IGNORED;
+
+    /* Find the worksheet name node by name. */
+    lookup.name = name;
+    node = RB_FIND(lxw_worksheet_names, self->worksheet_names, &lookup);
+
+    if (!node)
+        return LXW_ERROR_SHEETNAME_NOT_FOUND;
+
+    worksheet = node->worksheet;
+    removed_index = worksheet->index;
+
+    /* Remove the node from the name tree and free it. The name string it
+     * points at is owned by the worksheet and is freed by
+     * lxw_worksheet_free(). */
+    RB_REMOVE(lxw_worksheet_names, self->worksheet_names, node);
+    free(node);
+
+    /* Remove the worksheet from the worksheets list. */
+    STAILQ_REMOVE(self->worksheets, worksheet, lxw_worksheet, list_pointers);
+
+    /* Find, remove and free the lxw_sheet wrapper from the combined sheets
+     * list. */
+    STAILQ_FOREACH(sheet, self->sheets, list_pointers) {
+        if (!sheet->is_chartsheet && sheet->u.worksheet == worksheet)
+            break;
+    }
+    STAILQ_REMOVE(self->sheets, sheet, lxw_sheet, list_pointers);
+    free(sheet);
+
+    self->num_worksheets--;
+    self->num_sheets--;
+
+    /* Renumber the remaining sheets so their indexes stay contiguous. */
+    new_index = 0;
+    STAILQ_FOREACH(sheet, self->sheets, list_pointers) {
+        if (sheet->is_chartsheet)
+            sheet->u.chartsheet->index = new_index;
+        else
+            sheet->u.worksheet->index = new_index;
+        new_index++;
+    }
+
+    /* Shift the active/first sheet positions past the removed sheet, or reset
+     * them if the removed sheet was the active/first one. */
+    if (self->active_sheet > removed_index)
+        self->active_sheet--;
+    else if (self->active_sheet == removed_index)
+        self->active_sheet = 0;
+
+    if (self->first_sheet > removed_index)
+        self->first_sheet--;
+    else if (self->first_sheet == removed_index)
+        self->first_sheet = 0;
+
+    lxw_worksheet_free(worksheet);
+
+    return LXW_NO_ERROR;
+}
+
+/*
  * Get the default URL format.
  */
 lxw_format *

--- a/test/unit/workbook/test_workbook_remove_worksheet.c
+++ b/test/unit/workbook/test_workbook_remove_worksheet.c
@@ -1,0 +1,156 @@
+/*
+ * Tests for the libxlsxwriter library.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ * Copyright 2014-2026, John McNamara, jmcnamara@cpan.org.
+ *
+ */
+
+#include "../ctest.h"
+#include "../helper.h"
+
+#include "../../../include/xlsxwriter/workbook.h"
+#include "../../../include/xlsxwriter/shared_strings.h"
+
+
+/* Test removing a worksheet by name. */
+CTEST(workbook, remove_worksheet_basic) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *ws1 = workbook_add_worksheet(workbook, "Sheet1");
+    workbook_add_worksheet(workbook, "Sheet2");
+    lxw_worksheet *ws3 = workbook_add_worksheet(workbook, "Sheet3");
+
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet2");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(2, workbook->num_worksheets);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") == ws1);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet2") == NULL);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet3") == ws3);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test that removing a middle worksheet renumbers the remaining indexes. */
+CTEST(workbook, remove_worksheet_renumber_indexes) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *ws1 = workbook_add_worksheet(workbook, "Sheet1");
+    workbook_add_worksheet(workbook, "Sheet2");
+    lxw_worksheet *ws3 = workbook_add_worksheet(workbook, "Sheet3");
+    lxw_worksheet *ws4 = workbook_add_worksheet(workbook, "Sheet4");
+
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet2");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(0, ws1->index);
+    ASSERT_EQUAL(1, ws3->index);
+    ASSERT_EQUAL(2, ws4->index);
+    ASSERT_EQUAL(3, workbook->num_sheets);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test that removing the first worksheet renumbers the remaining indexes. */
+CTEST(workbook, remove_worksheet_first) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+    lxw_worksheet *ws2 = workbook_add_worksheet(workbook, "Sheet2");
+    lxw_worksheet *ws3 = workbook_add_worksheet(workbook, "Sheet3");
+
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet1");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(0, ws2->index);
+    ASSERT_EQUAL(1, ws3->index);
+    ASSERT_EQUAL(2, workbook->num_sheets);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") == NULL);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test removing the only worksheet leaves the workbook empty. */
+CTEST(workbook, remove_worksheet_only_sheet) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet1");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(0, workbook->num_worksheets);
+    ASSERT_EQUAL(0, workbook->num_sheets);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") == NULL);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test removing a worksheet that doesn't exist. */
+CTEST(workbook, remove_worksheet_not_found) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet9");
+
+    ASSERT_EQUAL(LXW_ERROR_SHEETNAME_NOT_FOUND, got);
+    ASSERT_EQUAL(1, workbook->num_worksheets);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") != NULL);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test removing a worksheet with a NULL name. */
+CTEST(workbook, remove_worksheet_null) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_remove_worksheet(workbook, NULL);
+
+    ASSERT_EQUAL(LXW_ERROR_NULL_PARAMETER_IGNORED, got);
+    ASSERT_EQUAL(1, workbook->num_worksheets);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test removing a worksheet that is before the active sheet shifts the
+ * active sheet position so it keeps pointing at the same sheet. */
+CTEST(workbook, remove_worksheet_before_active) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+    workbook_add_worksheet(workbook, "Sheet2");
+    lxw_worksheet *ws3 = workbook_add_worksheet(workbook, "Sheet3");
+
+    worksheet_activate(ws3);
+    ASSERT_EQUAL(2, workbook->active_sheet);
+
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet1");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(1, workbook->active_sheet);
+    ASSERT_EQUAL(1, ws3->index);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test removing the active worksheet resets the active sheet position. */
+CTEST(workbook, remove_worksheet_active) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+    lxw_worksheet *ws2 = workbook_add_worksheet(workbook, "Sheet2");
+    workbook_add_worksheet(workbook, "Sheet3");
+
+    worksheet_activate(ws2);
+    ASSERT_EQUAL(1, workbook->active_sheet);
+
+    lxw_error got = workbook_remove_worksheet(workbook, "Sheet2");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(0, workbook->active_sheet);
+
+    lxw_workbook_free(workbook);
+}
+

--- a/test/unit/workbook/test_workbook_rename_worksheet.c
+++ b/test/unit/workbook/test_workbook_rename_worksheet.c
@@ -1,0 +1,147 @@
+/*
+ * Tests for the libxlsxwriter library.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ * Copyright 2014-2026, John McNamara, jmcnamara@cpan.org.
+ *
+ */
+
+#include "../ctest.h"
+#include "../helper.h"
+
+#include "../../../include/xlsxwriter/workbook.h"
+#include "../../../include/xlsxwriter/shared_strings.h"
+
+
+/* Test renaming a worksheet by name. */
+CTEST(workbook, rename_worksheet_basic) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet1", "Sheet2");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_STR("Sheet2", worksheet->name);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet2") == worksheet);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") == NULL);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test renaming a worksheet that doesn't exist. */
+CTEST(workbook, rename_worksheet_not_found) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet9", "Sheet2");
+
+    ASSERT_EQUAL(LXW_ERROR_SHEETNAME_NOT_FOUND, got);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") != NULL);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet9") == NULL);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test renaming a worksheet to a name that is already in use. */
+CTEST(workbook, rename_worksheet_already_used) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    workbook_add_worksheet(workbook, "Sheet2");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet1", "Sheet2");
+
+    ASSERT_EQUAL(LXW_ERROR_SHEETNAME_ALREADY_USED, got);
+    /* The original worksheet is left unchanged on error. */
+    ASSERT_STR("Sheet1", worksheet->name);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") == worksheet);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test renaming a worksheet to a name with an invalid character. */
+CTEST(workbook, rename_worksheet_invalid_character) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet1", "Sheet[1]");
+
+    ASSERT_EQUAL(LXW_ERROR_INVALID_SHEETNAME_CHARACTER, got);
+    ASSERT_STR("Sheet1", worksheet->name);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test renaming a worksheet to an empty name. */
+CTEST(workbook, rename_worksheet_empty) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet1", "");
+
+    ASSERT_EQUAL(LXW_ERROR_PARAMETER_IS_EMPTY, got);
+    ASSERT_STR("Sheet1", worksheet->name);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test renaming a worksheet with a NULL old name. */
+CTEST(workbook, rename_worksheet_null_old_name) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, NULL, "Sheet2");
+
+    ASSERT_EQUAL(LXW_ERROR_NULL_PARAMETER_IGNORED, got);
+    ASSERT_STR("Sheet1", worksheet->name);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test renaming a worksheet with a NULL new name. */
+CTEST(workbook, rename_worksheet_null_new_name) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet1", NULL);
+
+    ASSERT_EQUAL(LXW_ERROR_NULL_PARAMETER_IGNORED, got);
+    ASSERT_STR("Sheet1", worksheet->name);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test a case-only rename which must be allowed (Sheet1 -> sheet1). */
+CTEST(workbook, rename_worksheet_case_only) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *worksheet = workbook_add_worksheet(workbook, "Sheet1");
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet1", "sheet1");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_STR("sheet1", worksheet->name);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "sheet1") == worksheet);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "Sheet1") == worksheet);
+    ASSERT_TRUE(workbook_get_worksheet_by_name(workbook, "SHEET1") == worksheet);
+
+    lxw_workbook_free(workbook);
+}
+
+/* Test that renaming a worksheet doesn't change its position/index. */
+CTEST(workbook, rename_worksheet_preserves_index) {
+    lxw_workbook *workbook = workbook_new(NULL);
+
+    lxw_worksheet *ws1 = workbook_add_worksheet(workbook, "Sheet1");
+    workbook_add_worksheet(workbook, "Sheet2");
+    lxw_worksheet *ws3 = workbook_add_worksheet(workbook, "Sheet3");
+
+    uint16_t index = ws3->index;
+    lxw_error got = workbook_rename_worksheet(workbook, "Sheet3", "Data");
+
+    ASSERT_EQUAL(LXW_NO_ERROR, got);
+    ASSERT_EQUAL(index, ws3->index);
+    ASSERT_EQUAL(0, ws1->index);
+    ASSERT_STR("Data", ws3->name);
+
+    lxw_workbook_free(workbook);
+}
+


### PR DESCRIPTION
## Summary

Adds two public workbook functions, both looking the worksheet up by name (case insensitive, matching `workbook_get_worksheet_by_name()`):

- `workbook_rename_worksheet(workbook, old_name, new_name)`
- `workbook_remove_worksheet(workbook, name)`

Also adds a new `LXW_ERROR_SHEETNAME_NOT_FOUND` error code for the lookup-miss case.

## Motivation

Downstream language bindings sometimes need to rename or drop a worksheet after it has been added. This came up for the PHP extension [php-ext-xlswriter#306](https://github.com/viest/php-ext-xlswriter/issues/306), where rename/delete of sheets is a frequently requested feature. These functions let bindings implement that without reaching into private structs.

## Design notes

- **Rename** detaches the name-tree node *before* validating `new_name`, so a case-only rename such as `Sheet1` -> `sheet1` is not treated as a collision. It preserves the single shared `worksheet->name` / name-node allocation used by `workbook_add_worksheet()`.
- **Remove** detaches the worksheet from the worksheets list, the combined sheets list and the name tree; frees the worksheet; then **renumbers the remaining sheet indexes** so they stay contiguous and **shifts the `active_sheet`/`first_sheet` positions** past the removed sheet (resetting them to 0 if the removed sheet was active/first, mirroring `worksheet_hide()`).
- The operations are purely additive — no existing function or behavior changes. Rename/remove should be carried out before a worksheet is referenced by formulas, defined names or charts in other worksheets (documented in the doxygen notes), the same constraint Excel itself has when deleting a sheet.

## Verification

- New unit tests: 9 rename cases, 8 remove cases (`test/unit/workbook/`).
- Mutation-tested the bug-prone paths: case-only rename (detach-before-validate), not-found return, index renumbering, and active/first-sheet shift each have a test that fails when the corresponding logic is removed.
- Full unit suite passes (455 tests across all modules, no regressions from the new error-code enum value).
- Compiles clean under `-Wall -Wextra -Wstrict-prototypes -pedantic -ansi`.
- End-to-end smoke: created a workbook, renamed a middle sheet, removed another middle sheet, set the active sheet to the last one, and closed — the generated `workbook.xml` has contiguous `sheetId`/`r:id`, the correct three `sheetN.xml` parts, and `activeTab` correctly tracking the shifted sheet.

I'm happy to split this into a rename-only PR and a remove-only PR, add a Changes.txt entry, or add the chartsheet counterparts (`workbook_rename/remove_chartsheet`, structurally identical) if that's preferred.